### PR TITLE
break: detach `worktop/cache` from `Router` by default

### DIFF
--- a/examples/workers/basic/index.ts
+++ b/examples/workers/basic/index.ts
@@ -1,4 +1,5 @@
 import { Router } from 'worktop';
+import { listen } from 'worktop/cache';
 
 const API = new Router();
 
@@ -13,4 +14,4 @@ API.add('GET', '/', (req, res) => {
 	res.end(`Howdy~! Please greet yourself; for example:\n\n  ${command}\n`);
 });
 
-addEventListener('fetch', API.listen);
+listen(API.run);

--- a/examples/workers/kv-todos/index.ts
+++ b/examples/workers/kv-todos/index.ts
@@ -1,4 +1,5 @@
 import { Router } from 'worktop';
+import { listen } from 'worktop/cache';
 import * as Todos from './routes';
 
 const API = new Router();
@@ -12,4 +13,4 @@ API.add('GET', '/users/:username/todos/:uid', Todos.show);
 API.add('PUT', '/users/:username/todos/:uid', Todos.update);
 API.add('DELETE', '/users/:username/todos/:uid', Todos.destroy);
 
-addEventListener('fetch', API.listen);
+listen(API.run);

--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,7 @@ $ npm install --save worktop
 
 ```ts
 import { Router } from 'worktop';
+import * as Cache from 'worktop/cache';
 import { uid as toUID } from 'worktop/utils';
 import { read, write } from 'worktop/kv';
 import type { KV } from 'worktop/kv';
@@ -123,8 +124,9 @@ API.add('GET', '/alive', (req, res) => {
 
 
 // Attach "fetch" event handler
-// ~> uses `Cache` for request-matching, when permitted
-addEventListener('fetch', API.listen);
+// ~> use `Cache` for request-matching, when permitted
+// ~> store Response in `Cache`, when permitted
+Cache.listen(API.run);
 ```
 
 ## API

--- a/src/cache.d.ts
+++ b/src/cache.d.ts
@@ -4,3 +4,18 @@ export const Cache: Cache;
 export function save(event: FetchEvent, res: Response, request?: Request | string): Response;
 export function lookup(event: FetchEvent, request?: Request | string): Promise<Response | void>;
 export function isCacheable(res: Response): boolean;
+
+export type ResponseHandler = (event: FetchEvent) => Promise<Response>;
+
+/**
+ * Attempt to `lookup` the `event.request`, otherwise run the `handler` and attempt to `save` the Response.
+ * @param {ResponseHandler} handler
+ */
+export function reply(handler: ResponseHandler): FetchHandler;
+
+/**
+ * Assign the `handler` to the "fetch" event.
+ * @note Your `handler` will be wrapped by `reply` automatically.
+ * @param {ResponseHandler} handler
+ */
+export function listen(handler: ResponseHandler): void;

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,3 +1,6 @@
+import type { FetchHandler } from 'worktop';
+import type { ResponseHandler } from 'worktop/cache';
+
 export const Cache: Cache = (caches as any).default;
 
 export function lookup(event: FetchEvent, request?: Request | string) {
@@ -29,4 +32,18 @@ export function isCacheable(res: Response): boolean {
 	}
 
 	return true;
+}
+
+export function reply(handler: ResponseHandler): FetchHandler {
+	return event => event.respondWith(
+		lookup(event).then(prev => {
+			return prev || handler(event).then(res => {
+				return save(event, res);
+			});
+		})
+	);
+}
+
+export function listen(handler: ResponseHandler): void {
+	addEventListener('fetch', reply(handler));
 }

--- a/src/response.d.ts
+++ b/src/response.d.ts
@@ -1,9 +1,5 @@
 /// <reference lib="webworker" />
 
-export type FetchHandler = (event: FetchEvent) => void;
-export type ResponseHandler = (event: FetchEvent) => Promise<Response> | Response;
-export function reply(handler: ResponseHandler): FetchHandler;
-
 export type HeadersObject = Record<string, string>;
 
 export declare class ServerResponse {

--- a/src/response.ts
+++ b/src/response.ts
@@ -1,18 +1,11 @@
 import { byteLength } from 'worktop/utils';
 import { CLENGTH, CTYPE } from './internal/constants';
 
-import type { FetchHandler, ResponseHandler } from 'worktop/response';
 import type { HeadersObject, ServerResponse as SR } from 'worktop/response';
 
 type Writable<T> = {
 	-readonly [P in keyof T]: T[P]
 };
-
-export function reply(handler: ResponseHandler): FetchHandler {
-	return event => event.respondWith(
-		handler(event)
-	);
-}
 
 export function ServerResponse(this: Writable<SR>, method: string): SR {
 	var $ = this, hh = $.headers = new Headers({

--- a/src/router.d.ts
+++ b/src/router.d.ts
@@ -1,16 +1,16 @@
 /// <reference lib="webworker" />
 
+import type { ServerResponse } from 'worktop/response';
 import type { ServerRequest, Params } from 'worktop/request';
-import type { ServerResponse, FetchHandler } from 'worktop/response';
 
 type Promisable<T> = Promise<T> | T;
+
+export type FetchHandler = (event: FetchEvent) => void;
+export type ResponseHandler = (event: FetchEvent) => Promisable<Response>;
 
 declare global {
 	function addEventListener(type: 'fetch', handler: FetchHandler): void;
 }
-
-export type FetchHandler = (event: FetchEvent) => void;
-export type ResponseHandler = (event: FetchEvent) => Promisable<Response>;
 
 /**
  * Return the `handler` with an `event.respondWith` wrapper.

--- a/src/router.d.ts
+++ b/src/router.d.ts
@@ -32,7 +32,6 @@ export declare class Router {
 	add(method: string, route: RegExp | string, handler: Handler): void;
 	find(method: string, pathname: string): Route;
 	run(event: FetchEvent): Promise<Response>;
-	listen(event: FetchEvent): void;
 	onerror(req: ServerRequest, res: ServerResponse, status?: number, error?: Error): Promisable<Response>;
 	prepare?(req: Omit<ServerRequest, 'params'>, res: ServerResponse): Promisable<void>;
 }

--- a/src/router.d.ts
+++ b/src/router.d.ts
@@ -9,6 +9,10 @@ declare global {
 	function addEventListener(type: 'fetch', handler: FetchHandler): void;
 }
 
+export type FetchHandler = (event: FetchEvent) => void;
+export type ResponseHandler = (event: FetchEvent) => Promisable<Response>;
+export function reply(handler: ResponseHandler): FetchHandler;
+
 export type Route = { params: Params; handler: Handler | false };
 export type Handler = (req: ServerRequest, res: ServerResponse) => Promisable<Response|void>;
 

--- a/src/router.d.ts
+++ b/src/router.d.ts
@@ -11,7 +11,19 @@ declare global {
 
 export type FetchHandler = (event: FetchEvent) => void;
 export type ResponseHandler = (event: FetchEvent) => Promisable<Response>;
+
+/**
+ * Return the `handler` with an `event.respondWith` wrapper.
+ * @param {ResponseHandler} handler
+ */
 export function reply(handler: ResponseHandler): FetchHandler;
+
+/**
+ * Assign the `handler` to the "fetch" event.
+ * @note Your `handler` will be wrapped by `reply` automatically.
+ * @param {ResponseHandler} handler
+ */
+export function listen(handler: ResponseHandler): void;
 
 export type Route = { params: Params; handler: Handler | false };
 export type Handler = (req: ServerRequest, res: ServerResponse) => Promisable<Response|void>;

--- a/src/router.ts
+++ b/src/router.ts
@@ -4,10 +4,17 @@ import { ServerRequest } from 'worktop/request';
 import { ServerResponse } from 'worktop/response';
 import { STATUS_CODES } from './internal/constants';
 
+import type { FetchHandler, ResponseHandler } from 'worktop';
 import type { Handler, Router as RR } from 'worktop';
 import type { Params } from 'worktop/request';
 
 export { STATUS_CODES };
+
+export function reply(handler: ResponseHandler): FetchHandler {
+	return event => event.respondWith(
+		handler(event)
+	);
+}
 
 interface Entry {
 	keys: string[];

--- a/src/router.ts
+++ b/src/router.ts
@@ -16,6 +16,10 @@ export function reply(handler: ResponseHandler): FetchHandler {
 	);
 }
 
+export function listen(handler: ResponseHandler): void {
+	addEventListener('fetch', reply(handler));
+}
+
 interface Entry {
 	keys: string[];
 	handler: Handler;

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,5 +1,4 @@
 import regexparam from 'regexparam';
-import * as Cache from 'worktop/cache';
 import { ServerRequest } from 'worktop/request';
 import { ServerResponse } from 'worktop/response';
 import { STATUS_CODES } from './internal/constants';
@@ -114,16 +113,6 @@ export function Router(): RR {
 			} catch (err) {
 				return call($.onerror, req, res, 500, err);
 			}
-		},
-
-		listen(event) {
-			event.respondWith(
-				Cache.lookup(event).then(prev => {
-					return prev || $.run(event).then(res => {
-						return Cache.save(event, res);
-					});
-				})
-			);
 		}
 	};
 }

--- a/types/check.ts
+++ b/types/check.ts
@@ -1,13 +1,12 @@
 import * as Cache from 'worktop/cache';
 import { Database, until } from 'worktop/kv';
-import { Router, STATUS_CODES } from 'worktop';
-import { reply, ServerResponse } from 'worktop/response';
+import { ServerResponse } from 'worktop/response';
+import { reply, Router, STATUS_CODES } from 'worktop';
 import { byteLength, HEX, uid, uuid } from 'worktop/utils';
 
 import type { KV } from 'worktop/kv';
+import type { FetchHandler, Route } from 'worktop';
 import type { ServerRequest, IncomingCloudflareProperties } from 'worktop/request';
-import type { FetchHandler } from 'worktop/response';
-import type { Route } from 'worktop';
 
 declare function assert<T>(value: T): void;
 

--- a/types/check.ts
+++ b/types/check.ts
@@ -1,8 +1,8 @@
 import * as Cache from 'worktop/cache';
 import { Database, until } from 'worktop/kv';
 import { ServerResponse } from 'worktop/response';
-import { reply, Router, STATUS_CODES } from 'worktop';
 import { byteLength, HEX, uid, uuid } from 'worktop/utils';
+import { listen, reply, Router, STATUS_CODES } from 'worktop';
 
 import type { KV } from 'worktop/kv';
 import type { FetchHandler, Route } from 'worktop';
@@ -178,9 +178,25 @@ async function foo1(event: FetchEvent) {
 }
 
 // @ts-expect-error
-reply(API.listen);
+reply(API.onerror);
+reply(API.run);
 
-addEventListener('fetch', API.listen);
+// @ts-expect-error
+addEventListener('fetch', API.find);
+addEventListener('fetch', reply(API.run));
+addEventListener('fetch', Cache.reply(API.run));
+
+// @ts-expect-error
+listen(reply(API.run));
+listen(API.run);
+
+// @ts-expect-error
+Cache.reply(API.onerror);
+Cache.reply(API.run);
+
+// @ts-expect-error
+Cache.listen(reply(API.run));
+Cache.listen(API.run);
 
 
 /**


### PR DESCRIPTION
## Motivation

Worktop should be a viable option for building Service Workers. More will done in this scope in the future, but in order to prepare for that, it's better to introduce this breaking sooner rather than later – before any habits start forming.

## Problem

Currently (before this PR) `Router.listen` pulled in `worktop/cache` so that it could run a `Cache.lookup` and then `Cache.save` the response, when able. This worked well for the Cloudflare Worker runtime, because CFW _uniquely_ exposes a `caches.default` global cache object... but that's not common to any other browser implementation:

> This API is strongly influenced by the web browsers’ Cache API, but there are some important differences. For instance, Cloudflare Workers runtime exposes a single global cache object.<br> – https://developers.cloudflare.com/workers/runtime-apis/cache#constructor

Because of this, the current `worktop/cache` module is incompatible with a browser Service Worker (SW), forcing any `worktop`-driven SW to be broken, by default. An application's `listen()` method  _could_ be overridden, but even after compiling & tree-shaking, the unused, broken code would still be included in the final output.

## Solution

It's best to _fully_ detach `worktop/cache` from the default Router, requiring you to _explicitly_ select how your application should behave. 

This PR adds a `reply` and `listen` utility to _both_ the `worktop` (router) and `worktop/cache` modules. Each module's `reply` utility will wrap the given handler function (eg, `Router.run`) with the appropriate behavior, as determined by that module's purpose.

So, when importing `reply` from `worktop` (the router), your handler is given a `event.respondWith` wrapper & that's it. Nothing else needs to happen as far as the Router is concerned, since its purpose is simply to respond with the `Response` that `Router.run()` generated.

If you'd like to involve the Cache API (***which was the default prior to this PR,*** via `Router.listen`), then you need to pull the `reply` utility from `worktop/cache` instead. In this case, every request passes through a `Cache.lookup` – if there was no usable response then then handler is invoked, which generates a Response that might be `Cache.save`d before ultimately being given to `event.respondWith`. Text descriptions are sub-par, so [here's the code](https://github.com/lukeed/worktop/compare/break/reply?expand=1#diff-d027d3b9853e6bedddf63bd1d8fa67c69b4c1ff2b947685108f315e4e831cdbdR37).

Finally, each module includes a `listen` utility, too.
This function accepts a handler, calls the _current_ module's `reply` on it for you, and then assigns the result as the `'fetch'` event listener. Both modules' `listen` implementation is exactly as follows:

```js
export function listen(handler) {
  addEventListener('fetch', reply(handler));
}
```

### Examples

***App without any Cache involvement***

```js
import { Router, reply } from 'worktop';

const API = new Router();
// ... routes ...

addEventListener('fetch', reply(API.run));
```

***App using `listen` & without any Cache involvement***

```js
import { Router, listen } from 'worktop';

const API = new Router();
// ... routes ...

listen(API.run);
```

***App relying on Cache lookup/save***

> **Important:** This matches the `0.1.x` default behavior!

```js
import { Router } from 'worktop';
import * as Cache from 'worktop/cache';

const API = new Router();
// ... routes ...

Cache.listen(API.run);
```

### Migration

When upgrading a worktop app from `0.1.x` to `0.2.x` (this PR), here are the appropriate changes to maintain identical behavior:

```diff
import { Router } from 'worktop';
++ import { reply } from 'worktop/cache';

const API = new Router();
// ... routes

-- addEventListener('fetch', API.listen);
++ addEventListener('fetch', reply(API.run));
```

Or, you may choose to involve the new `listen` utility, which initializes the `addEventListener` call for you too:

```diff
import { Router } from 'worktop';
++ import { listen } from 'worktop/cache';

const API = new Router();
// ... routes

-- addEventListener('fetch', API.listen);
++ listen(API.run);
```