### PR TITLE
feat(router): add `req.params` type-safety via string patterns;

### DIFF
--- a/src/request.d.ts
+++ b/src/request.d.ts
@@ -120,7 +120,7 @@ export interface IncomingCloudflareProperties {
 	timezone?: string;
 }
 
-export declare class ServerRequest {
+export declare class ServerRequest<P extends Params = Params> {
 	constructor(event: FetchEvent);
 	url: string;
 	path: string;
@@ -131,7 +131,7 @@ export declare class ServerRequest {
 	extend: FetchEvent['waitUntil'];
 	cf: IncomingCloudflareProperties;
 	headers: Headers;
-	params: Params;
+	params: P;
 	body: {
 		<T>(): Promise<T|void>;
 		json<T=any>(): Promise<T>;

--- a/src/router.ts
+++ b/src/router.ts
@@ -42,7 +42,7 @@ export function Router(): RR {
 	let $: RR, tree: Tree = {};
 
 	return $ = {
-		add(method, route, handler) {
+		add(method: string, route: RegExp | string, handler: Handler) {
 			let dict = tree[method];
 
 			if (dict === void 0) {


### PR DESCRIPTION
Shoutout to @dummdidumm for reminding me!

[TypeScript Playground](https://www.typescriptlang.org/play?ts=4.2.3#code/C4TwDgpgBACghgJzgWwM5QLxQEoQMYD2CAJgDyrAICWAdgOYA0UF19AfANwBQokOBAV2AR4SNKQAqUCAA9hNYumyDh8YMIQ02mLgEgps+YqgADACQBvWgDMICKAGUAvgC5LNu7CcB+APTuaW3tcCicTPV1vKAsoAG0AaShaWABdbxdmSlo6KCcoADJ+IRFEFFRSEOA2LigoDIM5CAV0cytAz2c3NqCvf27PSrCIqJiEpJpYKAAfKABrCBACayLVUvFKthSMlmzcmrqoBqMWgJ7O088YH3DdSOi4xOSYNO2s+j3a+ulG5tML+3O-XsVxud1Gjwmz1erByTn2GQsTm4PHA0GUxTUGgmWFwdAAojIwNNMjDuLxoAAJOAKAA2dlIMG+x1ga3QWFEZW0WAAFAgIABHDK4fkCCAUAr3MCsjKMpxMPmoIVisAEGioCAASkw2gAbgQqMRkcR8DTENBrAIaHhgFRVVA4MQyEcmsZcQSwGxucgIMAABYEYjQ7LylQQepMX3U4h0hAZKm0+kctBsDUZPUG7jGvCmvlQC1Wm12h1Opku9A7dhen3+wMk4NQBCh8NQSMJ2NQePR+no1ZicoSNgptP6w1cFF8ACCmBWJT7pAA5L5rAQCPPquSoAAhac92dlBe+FzL1fr1FQADCO9DSfKi6PK+8a7HG4nAEYrxjWQfj4eAEaIJ8N03d8cWvL87x-Fx-wQQCz3PECZxvA97wIPwoIA08+AAEQQ3ckIgh8-0QR9qnHaAJwAJg-Xt90XSDoN8f8AC9YL4TcqNAz85wIggiIQRi4BYzDoHPDjEPAw9jzQhjmNY6AsLEvCJJQ6TiIEoTnzPCcAGZqL3cQ6JXdS+LkrddM4miDMkozmJM4SL3M8TuOs1DjPQmD7KwxylOclS3Ogkix2Lbl5wAcTxCR5yYQzeJcA1HyYXkBXlMUtQwbQLH2XxfCgAABYBUAAWlkSBrWKhBGwQfY+X5AA6KU+1qmgUAgLgnA1ILHRC8LIuipcjLi4g0Oa70oqgJL+RS1A0oy6qBXq1kmpatqOq4YKwoisb+t4xKaqmmbojmuqGrKJbvRWsc1q6+cYAAeQcXqoB4saau1Q7ahqhbGuPFagA)

> **Note:** There's still a `TODO` for wildcard patterns (`/foo/*`, `/:foo/*`, `/:foo/*/:bar`) but this can come later.