### PR TITLE
fix bug in POST endpoint where it would timeout

### DIFF
--- a/bin/esbuild.js
+++ b/bin/esbuild.js
@@ -22,6 +22,7 @@ exports.build = function (input, output, externals=[]) {
 		outfile: output,
 		entryPoints: [input],
 		external: externals,
+		target: 'es2019',
 	});
 }
 

--- a/bin/esbuild.js
+++ b/bin/esbuild.js
@@ -2,7 +2,7 @@ const esbuild = require('esbuild');
 
 /** @type {esbuild.CommonOptions} */
 const options = {
-	target: 'esnext',
+	target: 'es2019',
 	sourcemap: false,
 	treeShaking: true,
 	minifySyntax: true,
@@ -22,7 +22,6 @@ exports.build = function (input, output, externals=[]) {
 		outfile: output,
 		entryPoints: [input],
 		external: externals,
-		target: 'es2019',
 	});
 }
 

--- a/src/kv.test.ts
+++ b/src/kv.test.ts
@@ -29,6 +29,20 @@ read('should call `get()` binding method', async () => {
 	assert.equal(binding.get.args(), ['foobar', 'text']);
 });
 
+read('should return false if `get()` returns null', async () => {
+	let binding = Namespace();
+	binding.get = Mock(null);
+
+	assert.is(await KV.read(binding, 'foobar'), false);
+});
+
+read('should return false if `get()` returns undefined', async () => {
+	let binding = Namespace();
+	binding.get = Mock(undefined);
+
+	assert.is(await KV.read(binding, 'foobar'), false);
+});
+
 read.run();
 
 // ---

--- a/src/kv.ts
+++ b/src/kv.ts
@@ -17,7 +17,7 @@ export function Database<M, I extends Record<keyof M, string> = { [P in keyof M]
 }
 
 export function read<T>(binding: KV.Namespace, key: string, format: KV.GetOptions = 'json'): Promise<T | false> {
-	return binding.get<T>(key, format).then(x => x !== void 0 ? x : false);
+	return binding.get<T>(key, format).then(x => x != null ? x : false);
 }
 
 export function write<T=any>(binding: KV.Namespace, key: string, value: T, toJSON?: boolean): Promise<boolean> {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "noEmit": true,
     "allowJs": true,
     "checkJs": true,
+    "target": "esnext",
     "skipLibCheck": true,
     "moduleResolution": "node",
     "forceConsistentCasingInFileNames": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,6 @@
     "noEmit": true,
     "allowJs": true,
     "checkJs": true,
-    "target": "esnext",
     "skipLibCheck": true,
     "moduleResolution": "node",
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
The `toSearch` function was never returning `false` because the `find` function returns `null` if it can not find a Todo record.

Adding a new function called `exists` which will always return a boolean. `true` if the record exists and `false` if it does not.