### PR TITLE
feat: add `worktop/cookie` module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules
 
 /kv
 /cache
+/cookie
 /crypto
 /base64
 /request

--- a/bin/index.js
+++ b/bin/index.js
@@ -28,6 +28,7 @@ async function bundle(input, output) {
 Promise.all([
 	bundle('src/router.ts', pkg.exports['.']),
 	bundle('src/cache.ts', pkg.exports['./cache']),
+	bundle('src/cookie.ts', pkg.exports['./cookie']),
 	bundle('src/base64.ts', pkg.exports['./base64']),
 	bundle('src/request.ts', pkg.exports['./request']),
 	bundle('src/response.ts', pkg.exports['./response']),

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     ".": "./router/index.mjs",
     "./kv": "./kv/index.mjs",
     "./cache": "./cache/index.mjs",
+    "./cookie": "./cookie/index.mjs",
     "./crypto": "./crypto/index.mjs",
     "./request": "./request/index.mjs",
     "./response": "./response/index.mjs",
@@ -23,9 +24,10 @@
     "./package.json": "./package.json"
   },
   "files": [
+    "base64",
     "cache",
     "crypto",
-    "base64",
+    "cookie",
     "request",
     "response",
     "router",

--- a/readme.md
+++ b/readme.md
@@ -177,6 +177,13 @@ The `worktop/response` submodule contains the [`ServerResponse`](/src/response.d
 
 The `worktop/base64` submodule contains a few utilities related to the [Base 64 encoding](https://tools.ietf.org/html/rfc4648#section-4).
 
+### Module: `worktop/cookie`
+
+> [View `worktop/cookie` API documentation](/src/cookie.d.ts)
+<!-- > [View `worktop/cookie` API documentation](/docs/module.cookie.md) -->
+
+The `worktop/cookie` submodule contains `parse` and `stringify` utilities for dealing with cookie header(s).
+
 ### Module: `worktop/utils`
 
 > [View `worktop/utils` API documentation](/src/utils.d.ts)

--- a/src/cookie.d.ts
+++ b/src/cookie.d.ts
@@ -1,0 +1,12 @@
+export interface Attributes {
+	maxage?: number;
+	expires?: Date;
+	samesite?: 'Lax' | 'Strict' | 'None';
+	secure?: boolean;
+	httponly?: boolean;
+	domain?: string;
+	path?: string;
+}
+
+export function parse(cookie: string): Attributes & Record<string, string>;
+export function stringify(name: string, value: string, options: Omit<Attributes, 'expires'> & { expires?: Date | number | string }): string;

--- a/src/cookie.test.ts
+++ b/src/cookie.test.ts
@@ -1,0 +1,343 @@
+import { suite } from 'uvu';
+import * as assert from 'uvu/assert';
+import * as Cookie from './cookie';
+
+// ---
+
+const stringify = suite('stringify');
+
+stringify('should be a function', () => {
+	assert.type(Cookie.stringify, 'function');
+});
+
+stringify('should stringify a name=value pair', () => {
+	assert.is(
+		Cookie.stringify('foo', 'bar'),
+		'foo=bar'
+	);
+});
+
+stringify('should encode the value', () => {
+	assert.is(
+		Cookie.stringify('foobar', 'hello world'),
+		'foobar=hello%20world'
+	);
+});
+
+stringify('should allow attributes :: expires', () => {
+	const expires = new Date;
+
+	assert.is(
+		Cookie.stringify('foo', 'bar', { expires }),
+		`foo=bar; Expires=${expires.toUTCString()}`
+	);
+
+	assert.is(
+		Cookie.stringify('foo', 'bar', { expires: +expires }),
+		`foo=bar; Expires=${expires.toUTCString()}`
+	);
+
+	assert.is(
+		Cookie.stringify('foo', 'bar', { expires: expires.toUTCString() }),
+		`foo=bar; Expires=${expires.toUTCString()}`
+	);
+});
+
+stringify('should allow attributes :: maxage', () => {
+	assert.is(
+		Cookie.stringify('foo', 'bar', { maxage: 0 }),
+		`foo=bar; Max-Age=0`
+	);
+
+	assert.is(
+		Cookie.stringify('foo', 'bar', { maxage: 10e3 }),
+		`foo=bar; Max-Age=10000`
+	);
+});
+
+stringify('should allow attributes :: secure', () => {
+	assert.is(
+		Cookie.stringify('foo', 'bar', { secure: true }),
+		`foo=bar; Secure`
+	);
+
+	assert.is(
+		Cookie.stringify('foo', 'bar', { secure: false }),
+		`foo=bar`
+	);
+});
+
+stringify('should allow attributes :: httponly', () => {
+	assert.is(
+		Cookie.stringify('foo', 'bar', { httponly: true }),
+		`foo=bar; HttpOnly`
+	);
+
+	assert.is(
+		Cookie.stringify('foo', 'bar', { httponly: false }),
+		`foo=bar`
+	);
+});
+
+stringify('should allow attributes :: httponly + secure', () => {
+	assert.is(
+		Cookie.stringify('foo', 'bar', { httponly: true, secure: true }),
+		`foo=bar; Secure; HttpOnly`
+	);
+
+	assert.is(
+		Cookie.stringify('foo', 'bar', { httponly: false, secure: true }),
+		`foo=bar; Secure`
+	);
+});
+
+stringify('should allow attributes :: samesite', () => {
+	assert.is(
+		Cookie.stringify('foo', 'bar', { samesite: 'Lax' }),
+		`foo=bar; SameSite=Lax`
+	);
+
+	assert.is(
+		Cookie.stringify('foo', 'bar', { samesite: 'Strict' }),
+		`foo=bar; SameSite=Strict`
+	);
+
+	assert.is(
+		Cookie.stringify('foo', 'bar', { samesite: 'None' }),
+		`foo=bar; SameSite=None; Secure`
+	);
+});
+
+stringify('should allow attributes :: samesite + secure', () => {
+	assert.is(
+		Cookie.stringify('foo', 'bar', { secure: true, samesite: 'Lax' }),
+		`foo=bar; SameSite=Lax; Secure`
+	);
+
+	assert.is(
+		Cookie.stringify('foo', 'bar', { secure: true, samesite: 'Strict' }),
+		`foo=bar; SameSite=Strict; Secure`
+	);
+
+	assert.is(
+		Cookie.stringify('foo', 'bar', { secure: true, samesite: 'None' }),
+		`foo=bar; SameSite=None; Secure`
+	);
+});
+
+stringify('should allow attributes :: domain', () => {
+	assert.is(
+		Cookie.stringify('foo', 'bar', { domain: 'mozilla.org' }),
+		`foo=bar; Domain=mozilla.org`
+	);
+
+	assert.is(
+		Cookie.stringify('foo', 'bar', { domain: '.example.com' }),
+		`foo=bar; Domain=.example.com`
+	);
+});
+
+stringify('should allow attributes :: path', () => {
+	assert.is(
+		Cookie.stringify('foo', 'bar', { path: '/' }),
+		`foo=bar; Path=/`
+	);
+
+	assert.is(
+		Cookie.stringify('foo', 'bar', { path: '/docs' }),
+		`foo=bar; Path=/docs`
+	);
+});
+
+stringify('should allow attributes :: kitchen sink', () => {
+	const NOW = new Date;
+
+	let output = Cookie.stringify('foo', 'bar', {
+		expires: NOW,
+		domain: 'example.com',
+		samesite: 'Strict',
+		maxage: 123456789,
+		httponly: true,
+		secure: true,
+		path: '/api',
+	});
+
+	assert.is(output, `foo=bar; Expires=${NOW.toUTCString()}; Max-Age=123456789; Domain=example.com; Path=/api; SameSite=Strict; Secure; HttpOnly`);
+});
+
+stringify.run();
+
+
+// ---
+
+
+const parse = suite('parse');
+
+parse('should be a function', () => {
+	assert.type(Cookie.parse, 'function');
+});
+
+parse('should convert a string into a object', () => {
+	assert.equal(
+		Cookie.parse('foo=bar'),
+		{ foo: 'bar' }
+	);
+});
+
+parse('should decode string value', () => {
+	assert.equal(
+		Cookie.parse('foobar=hello%20world'),
+		{ foobar: 'hello world' }
+	);
+});
+
+parse('should maintain original value when decode fails', () => {
+	assert.equal(
+		Cookie.parse('foobar=foo%%bar'),
+		{ foobar: 'foo%%bar' }
+	);
+});
+
+parse('should unwrap quoted "value"s', () => {
+	assert.equal(
+		Cookie.parse('foo="bar"'),
+		{ foo: 'bar' }
+	);
+});
+
+parse('should unwrap quoted "value"s', () => {
+	assert.equal(
+		Cookie.parse('foo="bar"'),
+		{ foo: 'bar' }
+	);
+});
+
+parse('should decode attributes :: expires', () => {
+	const expires = new Date;
+	expires.setUTCMilliseconds(0);
+	const output = Cookie.parse(`foo=bar; Expires=${expires.toUTCString()}`);
+	assert.instance(output.expires, Date);
+
+	assert.equal(output, {
+		foo: 'bar',
+		expires: expires
+	});
+});
+
+parse('should decode attributes :: maxage', () => {
+	const output = Cookie.parse(`foo=bar; Max-Age=0`);
+	assert.type(output.maxage, 'number');
+
+	assert.equal(output, {
+		'foo': 'bar',
+		maxage: 0
+	});
+
+	assert.equal(
+		Cookie.parse(`foo=bar; Max-Age=10000`),
+		{ 'foo': 'bar', maxage: 10e3 },
+	);
+});
+
+parse('should decode attributes :: secure', () => {
+	assert.equal(
+		Cookie.parse(`foo=bar; Secure`),
+		{ 'foo': 'bar', secure: true },
+	);
+});
+
+parse('should decode attributes :: httponly', () => {
+	assert.equal(
+		Cookie.parse(`foo=bar; HttpOnly`),
+		{ 'foo': 'bar', httponly: true },
+	);
+
+	assert.equal(
+		Cookie.parse(`foo=bar; Secure; HttpOnly`),
+		{ 'foo': 'bar', httponly: true, secure: true },
+	);
+
+	assert.equal(
+		Cookie.parse(`foo=bar; HttpOnly; Secure`),
+		{ 'foo': 'bar', httponly: true, secure: true },
+	);
+});
+
+parse('should decode attributes :: samesite', () => {
+	assert.equal(
+		Cookie.parse(`foo=bar; SameSite=Lax`),
+		{ 'foo': 'bar', samesite: 'Lax' },
+	);
+
+	assert.equal(
+		Cookie.parse(`foo=bar; SameSite=Strict`),
+		{ 'foo': 'bar', samesite: 'Strict' },
+	);
+
+	assert.equal(
+		Cookie.parse(`foo=bar; SameSite=None; Secure`),
+		{ 'foo': 'bar', samesite: 'None', secure: true },
+	);
+});
+
+parse('should decode attributes :: samesite + secure', () => {
+	assert.equal(
+		Cookie.parse(`foo=bar; SameSite=Lax; Secure`),
+		{ 'foo': 'bar', secure: true, samesite: 'Lax' },
+	);
+
+	assert.equal(
+		Cookie.parse(`foo=bar; SameSite=Strict; Secure`),
+		{ 'foo': 'bar', secure: true, samesite: 'Strict' },
+	);
+
+	assert.equal(
+		Cookie.parse(`foo=bar; SameSite=None; Secure`),
+		{ 'foo': 'bar', secure: true, samesite: 'None' },
+	);
+});
+
+parse('should decode attributes :: domain', () => {
+	assert.equal(
+		Cookie.parse(`foo=bar; Domain=mozilla.org`),
+		{ 'foo': 'bar', domain: 'mozilla.org' },
+	);
+
+	assert.equal(
+		Cookie.parse(`foo=bar; Domain=.example.com`),
+		{ 'foo': 'bar', domain: '.example.com' },
+	);
+});
+
+parse('should decode attributes :: path', () => {
+	assert.equal(
+		Cookie.parse(`foo=bar; Path=/`),
+		{ 'foo': 'bar', path: '/' },
+	);
+
+	assert.equal(
+		Cookie.parse(`foo=bar; Path=/docs`),
+		{ 'foo': 'bar', path: '/docs' },
+	);
+});
+
+parse('should decode attributes :: kitchen sink', () => {
+	const NOW = new Date;
+	NOW.setUTCMilliseconds(0);
+
+	assert.equal(
+		Cookie.parse(`foo=bar; Expires=${NOW.toUTCString()}; Max-Age=123456789; Domain=example.com; Path=/api; SameSite=Strict; Secure; HttpOnly`),
+		{
+			foo: 'bar',
+			expires: NOW,
+			domain: 'example.com',
+			samesite: 'Strict',
+			maxage: 123456789,
+			httponly: true,
+			secure: true,
+			path: '/api',
+		}
+	);
+});
+
+parse.run();

--- a/src/cookie.ts
+++ b/src/cookie.ts
@@ -1,0 +1,73 @@
+import type { Attributes } from 'worktop/cookie';
+
+const ATTRS = new Set([
+	'domain', 'path', 'max-age', 'expires',
+	'samesite', 'secure', 'httponly',
+]);
+
+type Cookie = Attributes & Record<string, string>;
+export function parse(cookie: string): Cookie {
+	let out: Cookie = {}, idx: number, tmp: string;
+	let i=0, arr=cookie.split(/;\s*/g);
+	let key: string, val: string;
+
+	for (; i < arr.length; i++) {
+		tmp = arr[i];
+		idx = tmp.indexOf('=');
+
+		if (!!~idx) {
+			key = tmp.substring(0, idx++).trim();
+			val = tmp.substring(idx).trim();
+			if (val[0] === '"') {
+				val = val.substring(1, val.length - 1);
+			}
+			if (!!~val.indexOf('%')) {
+				try { val = decodeURIComponent(val) }
+				catch (err) { /* ignore */ }
+			}
+			if (ATTRS.has(tmp = key.toLowerCase())) {
+				if (tmp === 'expires') out.expires = new Date(val);
+				else if (tmp === 'max-age') out.maxage = +val;
+				else out[tmp] = val;
+			} else {
+				out[key] = val;
+			}
+		} else if (key = tmp.trim().toLowerCase()) {
+			if (key === 'httponly' || key === 'secure') {
+				out[key] = true;
+			}
+		}
+	}
+
+	return out;
+}
+
+type Options = Omit<Attributes, 'expires'> & { expires?: Date | string | number };
+export function stringify(name: string, value: string, options: Options = {}): string {
+	let str = name + '=' + encodeURIComponent(value);
+
+	if (options.expires) {
+		str += '; Expires=' + new Date(options.expires).toUTCString();
+	}
+
+	if (options.maxage != null && options.maxage >= 0) {
+		str += '; Max-Age=' + (options.maxage | 0);
+	}
+
+	if (options.domain) {
+		str += '; Domain=' + options.domain;
+	}
+
+	if (options.path) {
+		str += '; Path=' + options.path;
+	}
+
+	if (options.samesite) {
+		str += '; SameSite=' + options.samesite;
+	}
+
+	if (options.secure || options.samesite === 'None') str += '; Secure';
+	if (options.httponly) str += '; HttpOnly';
+
+	return str;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
       "worktop/base64": ["./base64.d.ts", "./base64.ts"],
       "worktop/request": ["./request.d.ts", "./request.ts"],
       "worktop/response": ["./response.d.ts", "./response.ts"],
+      "worktop/cookie": ["./cookie.d.ts", "./cookie.ts"],
       "worktop/utils": ["./utils.d.ts", "./utils.ts"],
       "worktop/kv": ["./kv.d.ts", "./kv.js"],
     }


### PR DESCRIPTION
Add `worktop/cookie` module for ready-made cookie utilities. Relies on TS for options' validity, meaning there aren't any runtime checks when `stringify`'ing. Calling `parse` will return an object with attributes' values casted to `boolean/Date/number` when appropriate for the key.