### PR TITLE
chore(utils): add named `UID` and `UUID` types

### DIFF
--- a/examples/workers/kv-todos/model.ts
+++ b/examples/workers/kv-todos/model.ts
@@ -1,11 +1,12 @@
 import * as DB from 'worktop/kv';
 import { uid as toUID } from 'worktop/utils';
+import type { UID } from 'worktop/utils';
 import type { KV } from 'worktop/kv';
 
 declare const TODOS: KV.Namespace;
 
 export interface Todo {
-	uid: string;
+	uid: UID<8>;
 	title: string;
 	done: boolean;
 	created_at: number;

--- a/src/utils.d.ts
+++ b/src/utils.d.ts
@@ -15,13 +15,15 @@ export function toHEX(input: ArrayBuffer): string;
  * @NOTE Relies on `crypto` to produce cryptographically secure (CSPRNG) values.
  * @param {number} [len] The desired length (defaults to `11`)
  */
-export function uid(len?: number): string;
+export function uid<N extends number = 11>(len?: N): UID<N>;
+export type UID<N extends number> = { 0: string; length: N } & string;
 
 /**
  * Generate a new UUID.V4 value.
  * @NOTE Relies on `crypto` to produce cryptographically secure (CSPRNG) values.
  */
-export function uuid(): string;
+export function uuid(): UUID;
+export type UUID = { 0: string; length: 36 } & string;
 
 /**
  * Reusable `TextEncoder` instance.

--- a/types/check.ts
+++ b/types/check.ts
@@ -6,6 +6,7 @@ import { byteLength, HEX, uid, uuid } from 'worktop/utils';
 import { listen, reply, Router, STATUS_CODES } from 'worktop';
 
 import type { KV } from 'worktop/kv';
+import type { UID, UUID } from 'worktop/utils';
 import type { FetchHandler, Route, RouteParams } from 'worktop';
 import type { Params, ServerRequest, IncomingCloudflareProperties } from 'worktop/request';
 
@@ -430,10 +431,22 @@ assert<readonly string[]>(HEX);
 
 assert<Function>(uid);
 assert<string>(uid(24));
+assert<Fixed.String<24>>(uid(24));
+assert<UID<24>>(uid(24));
 assert<string>(uid());
+assert<Fixed.String<11>>(uid());
+assert<UID<11>>(uid());
+
+// @ts-expect-error
+assert<UID<24>>(uid(32));
 
 assert<Function>(uuid);
 assert<string>(uuid());
+assert<UUID>(uuid());
+
+// @ts-expect-error
+assert<Fixed.String<11>>(uuid());
+assert<UID<36>>(uuid());
 
 assert<Function>(byteLength);
 assert<number>(byteLength(undefined));


### PR DESCRIPTION
Since `uid` and `uuid` both return fixed-length strings, it's helpful to actually type those results (and export those types) from the package. Doing this allows a "model" interface to declare its own `uid`-length requirements, making it easier to be more explicit throughout the application:

```ts
import type { UID } from 'worktop/utils';

// Item should have 32-char IDs
export interface User {
  id: UID<32>;
  name: string;
  // ...
}

// Item should have 24-char IDs
export interface Item {
  id: UID<24>;
  title: string;
  // ...
}
```

The above adds an extra layer of protection so that a `Item['id']` value cannot satisfy an `User['id']` _because_ the lengths are different.

If you want to _opt out_ of this, then continue using `string` in your interface(s) as the new `UID` and `UUID` types still satisfy the `string` requirement:

```ts
// User should have ~string~ IDs
export interface User {
  id: string;
  name: string;
  // ...
}

// Item should have ~string~ IDs
export interface Item {
  id: string;
  title: string;
  // ...
}
```