### PR TITLE
feat: add `worktop/cors` module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules
 *.lock
 
 /kv
+/cors
 /cache
 /cookie
 /crypto

--- a/bin/index.js
+++ b/bin/index.js
@@ -32,7 +32,8 @@ Promise.all([
 	bundle('src/base64.ts', pkg.exports['./base64']),
 	bundle('src/request.ts', pkg.exports['./request']),
 	bundle('src/response.ts', pkg.exports['./response']),
-  bundle('src/crypto.ts', pkg.exports['./crypto']),
+	bundle('src/crypto.ts', pkg.exports['./crypto']),
 	bundle('src/utils.ts', pkg.exports['./utils']),
+	bundle('src/cors.ts', pkg.exports['./cors']),
 	bundle('src/kv.ts', pkg.exports['./kv']),
 ]).then(table);

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "exports": {
     ".": "./router/index.mjs",
     "./kv": "./kv/index.mjs",
+    "./cors": "./cors/index.mjs",
     "./cache": "./cache/index.mjs",
     "./cookie": "./cookie/index.mjs",
     "./crypto": "./crypto/index.mjs",
@@ -32,6 +33,7 @@
     "response",
     "router",
     "utils",
+    "cors",
     "kv"
   ],
   "engines": {

--- a/src/cors.d.ts
+++ b/src/cors.d.ts
@@ -1,0 +1,71 @@
+import type { Handler } from 'worktop';
+import type { ServerResponse } from 'worktop/response';
+
+export interface Config {
+	/**
+	 * The specific origin to allow.
+	 * Sets the `Access-Control-Allow-Origin` header.
+	 * @default "*" – Allows all origins by default.
+	 * @example "https://example.com"
+	 */
+	origin: string;
+	/**
+	 * The duration (in seconds) that a preflight results can be cached.
+	 * Sets the `Access-Control-Max-Age` header.
+	 * @example 3600 – Caches for 1 hour
+	 */
+	maxage?: number;
+	/**
+	 * The methods allowed when accessing the resource
+	 * Sets the `Access-Control-Allow-Methods` header.
+	 * @default ['GET','HEAD','PUT','PATCH','POST','DELETE']
+	 */
+	methods?: string[];
+	/**
+	 * Whether or not the actual request can be made using credentials.
+	 * Sets the `Access-Control-Allow-Credentials` header.
+	 * @default false
+	 */
+	credentials?: boolean;
+	/**
+	 * The HTTP headers that can be used when making the actual request.
+	 * Sets the `Access-Control-Allow-Headers` header.
+	 * @default request.headers.get('Access-Control-Request-Headers') || []
+	 */
+	headers?: string[];
+	/**
+	 * The HTTP response header names that a client is allowed to access.
+	 * Sets the `Access-Control-Expose-Headers` header.
+	 * @default []
+	 */
+	expose?: string[];
+}
+
+/**
+ * The defaults used for CORS construction.
+ */
+export const config: Config;
+
+/**
+ * Apply CORS headers.
+ * Conditionallyy sets headers for preflight (aka OPTIONS) requests.
+ * @NOTE Values in `options` are given priority, otherwise the `config` defaults are used.
+ */
+export function headers(res: ServerResponse, options?: Partial<Config>, isPreflight?: boolean): void;
+
+type PreflightConfig = Omit<Config, 'origin'> & {
+	/**
+	 * When a string, only requests from the specified value are allowed.
+	 * When `true`, the incoming `Origin` header will always be allowed.
+	 * When a RegExp, matching `Origin` header values will be allowed.
+	 * When `false`, allows any origin – equivalent to `"*"` value.
+	 * @default "*"
+	 */
+	origin?: string | boolean | RegExp;
+}
+
+/**
+ * Apply all CORS headers (see `headers` export)
+ * Will also handle preflight (aka, OPTIONS) requests.
+ */
+export function preflight(options?: PreflightConfig): Handler;

--- a/src/cors.test.ts
+++ b/src/cors.test.ts
@@ -1,0 +1,364 @@
+import { suite } from 'uvu';
+import * as assert from 'uvu/assert';
+import * as CORS from './cors';
+
+import type { ServerResponse } from 'worktop/response';
+import type { ServerRequest } from 'worktop/request';
+
+const Headers = () => {
+	let raw = new Map;
+	let set = raw.set.bind(raw);
+	// @ts-ignore - mutating
+	raw.set = (k, v) => set(k, String(v));
+	// @ts-ignore - mutating
+	raw.append = (k, v) => {
+		let val = raw.get(k) || '';
+		if (val) val += ', ';
+		val += String(v);
+		set(k, val);
+	}
+	// @ts-ignore - ctor
+	return raw as Headers;
+}
+
+const Response = () => {
+	let headers = Headers();
+	let body: any, finished = false;
+	// @ts-ignore
+	return {
+		headers,
+		finished,
+		statusCode: 0,
+		setHeader: headers.set,
+		body: () => body,
+		end(val: any) {
+			finished = true;
+			body = val;
+		}
+	} as ServerResponse;
+}
+
+const Request = (method = 'GET'): ServerRequest => {
+	let headers = Headers();
+	return { method, headers } as ServerRequest;
+}
+
+// ---
+
+const config = suite('config');
+
+config('should be an object', () => {
+	assert.type(CORS.config, 'object');
+});
+
+config('should allow "*" origin by default', () => {
+	assert.is(CORS.config.origin, '*');
+});
+
+config('should be mutable', () => {
+	const original = CORS.config.methods;
+	assert.equal(original, ['GET', 'HEAD', 'PUT', 'PATCH', 'POST', 'DELETE']);
+
+	CORS.config.methods = ['GET'];
+	assert.not.equal(CORS.config.methods, original);
+	assert.equal(CORS.config.methods, ['GET']);
+
+	assert.equal(CORS.config.headers, []);
+	CORS.config.headers!.push('x-foobarbaz');
+	assert.is(CORS.config.headers!.length, 1);
+
+	CORS.config.methods = original; // reset
+	CORS.config.headers = []; // reset
+});
+
+config.run();
+
+// ---
+
+const headers = suite('headers');
+
+headers('should be a function', () => {
+	assert.type(CORS.headers, 'function');
+});
+
+headers('defaults :: request', () => {
+	let res = Response();
+
+	assert.is(
+		CORS.headers(res),
+		undefined
+	);
+
+	let headers = Object.fromEntries(res.headers);
+
+	assert.is(headers['Vary'], undefined);
+	assert.is(headers['Access-Control-Allow-Origin'], '*');
+	assert.is(headers['Access-Control-Expose-Headers'], undefined);
+	assert.is(headers['Access-Control-Allow-Credentials'], undefined);
+
+	assert.is(headers['Access-Control-Max-Age'], undefined); // preflight only
+	assert.is(headers['Access-Control-Allow-Headers'], undefined); // preflight only
+	assert.is(headers['Access-Control-Allow-Methods'], undefined); // preflight only
+});
+
+headers('defaults :: preflight', () => {
+	let res = Response();
+	CORS.headers(res, undefined, true);
+
+	let headers = Object.fromEntries(res.headers);
+
+	assert.is(headers['Vary'], undefined);
+	assert.is(headers['Access-Control-Allow-Origin'], '*');
+	assert.is(headers['Access-Control-Expose-Headers'], undefined);
+	assert.is(headers['Access-Control-Allow-Credentials'], undefined);
+
+	assert.is(headers['Access-Control-Max-Age'], undefined);
+	assert.is(headers['Access-Control-Allow-Headers'], undefined);
+	assert.is(headers['Access-Control-Allow-Methods'], 'GET,HEAD,PUT,PATCH,POST,DELETE');
+});
+
+headers('config :: request', () => {
+	let res = Response();
+
+	CORS.headers(res, {
+		origin: 'https://foobar.com',
+		expose: ['X-My-Custom-Header', 'X-Another-Custom-Header'],
+		credentials: true,
+		maxage: 123
+	});
+
+	let headers = Object.fromEntries(res.headers);
+
+	assert.is(headers['Vary'], 'Origin'); // static origin
+	assert.is(headers['Access-Control-Allow-Origin'], 'https://foobar.com');
+	assert.is(headers['Access-Control-Expose-Headers'], 'X-My-Custom-Header,X-Another-Custom-Header');
+	assert.is(headers['Access-Control-Allow-Credentials'], 'true');
+
+	assert.is(headers['Access-Control-Max-Age'], undefined); // not preflight
+	assert.is(headers['Access-Control-Allow-Headers'], undefined); // not preflight
+	assert.is(headers['Access-Control-Allow-Methods'], undefined); // not preflight
+});
+
+headers('config :: preflight', () => {
+	let res = Response();
+
+	CORS.headers(res, {
+		origin: 'https://foobar.com',
+		expose: ['X-My-Custom-Header', 'X-Another-Custom-Header'],
+		headers: ['X-PINGOTHER', 'Content-Type'],
+		methods: ['POST', 'PUT', 'DELETE'],
+		credentials: true,
+		maxage: 123
+	}, true);
+
+	let headers = Object.fromEntries(res.headers);
+
+	assert.is(headers['Vary'], 'Origin'); // static origin
+	assert.is(headers['Access-Control-Allow-Origin'], 'https://foobar.com');
+	assert.is(headers['Access-Control-Expose-Headers'], 'X-My-Custom-Header,X-Another-Custom-Header');
+	assert.is(headers['Access-Control-Allow-Credentials'], 'true');
+
+	assert.is(headers['Access-Control-Max-Age'], '123');
+	assert.is(headers['Access-Control-Allow-Headers'], 'X-PINGOTHER,Content-Type');
+	assert.is(headers['Access-Control-Allow-Methods'], 'POST,PUT,DELETE');
+});
+
+headers('merge :: request', () => {
+	let res = Response();
+
+	CORS.headers(res, {
+		credentials: true,
+		maxage: 0
+	});
+
+	let headers = Object.fromEntries(res.headers);
+
+	assert.is(headers['Vary'], undefined); // "*" default
+	assert.is(headers['Access-Control-Allow-Origin'], '*');
+	assert.is(headers['Access-Control-Expose-Headers'], undefined);
+	assert.is(headers['Access-Control-Allow-Credentials'], 'true');
+
+	assert.is(headers['Access-Control-Max-Age'], undefined); // not preflight
+	assert.is(headers['Access-Control-Allow-Headers'], undefined); // not preflight
+	assert.is(headers['Access-Control-Allow-Methods'], undefined); // not preflight
+});
+
+headers('merge :: preflight', () => {
+	let res = Response();
+
+	CORS.headers(res, {
+		credentials: true,
+		maxage: 0
+	}, true);
+
+	let headers = Object.fromEntries(res.headers);
+
+	assert.is(headers['Vary'], undefined); // "*" default
+	assert.is(headers['Access-Control-Allow-Origin'], '*');
+	assert.is(headers['Access-Control-Expose-Headers'], undefined);
+	assert.is(headers['Access-Control-Allow-Credentials'], 'true');
+
+	assert.is(headers['Access-Control-Max-Age'], '0'); // allows 0
+	assert.is(headers['Access-Control-Allow-Headers'], undefined);
+	assert.is(headers['Access-Control-Allow-Methods'], 'GET,HEAD,PUT,PATCH,POST,DELETE'); // default
+});
+
+headers.run();
+
+// ---
+
+const preflight = suite('preflight');
+
+preflight('should be a function', () => {
+	assert.type(CORS.preflight, 'function');
+});
+
+preflight('defaults :: standard', () => {
+	let req=Request(), res=Response();
+	let handler = CORS.preflight();
+
+	assert.type(handler, 'function');
+	let out = handler(req, res);
+	assert.is(out, undefined);
+
+	let headers = Object.fromEntries(res.headers);
+
+	assert.is(headers['Vary'], undefined);
+	assert.is(headers['Access-Control-Allow-Origin'], '*');
+	assert.is(headers['Access-Control-Expose-Headers'], undefined);
+	assert.is(headers['Access-Control-Allow-Credentials'], undefined);
+
+	assert.is(headers['Access-Control-Max-Age'], undefined); // preflight only
+	assert.is(headers['Access-Control-Allow-Headers'], undefined); // preflight only
+	assert.is(headers['Access-Control-Allow-Methods'], undefined); // preflight only
+
+	// @ts-ignore - no response handler
+	assert.is(res.body(), undefined);
+	assert.is(res.statusCode, 0);
+});
+
+preflight('defaults :: preflight', () => {
+	let req = Request('OPTIONS');
+	let res = Response();
+
+	CORS.preflight()(req, res);
+
+	let headers = Object.fromEntries(res.headers);
+
+	// no headers config, must expect to be dynamic/varied
+	assert.is(headers['Vary'], 'Access-Control-Request-Headers');
+
+	assert.is(headers['Access-Control-Allow-Origin'], '*');
+	assert.is(headers['Access-Control-Expose-Headers'], undefined);
+	assert.is(headers['Access-Control-Allow-Credentials'], undefined);
+
+	assert.is(headers['Access-Control-Max-Age'], undefined); // no value
+	assert.is(headers['Access-Control-Allow-Headers'], undefined); // no value
+	assert.is(headers['Access-Control-Allow-Methods'], 'GET,HEAD,PUT,PATCH,POST,DELETE'); // default
+
+	// @ts-ignore
+	assert.is(res.body(), null);
+	assert.is(res.statusCode, 204);
+});
+
+preflight('custom :: headers :: static', () => {
+	let req = Request('OPTIONS');
+	let res = Response();
+
+	CORS.preflight({
+		headers: ['X-PINGOTHER', 'Content-Type']
+	})(req, res);
+
+	let headers = Object.fromEntries(res.headers);
+
+	// had static headers config
+	assert.is(headers['Vary'], undefined);
+	assert.is(headers['Access-Control-Allow-Headers'], 'X-PINGOTHER,Content-Type');
+});
+
+preflight('custom :: headers :: reflect', () => {
+	let req = Request('OPTIONS');
+	let res = Response();
+
+	req.headers.set('Access-Control-Request-Headers', 'Content-Type');
+
+	CORS.preflight()(req, res);
+
+	let headers = Object.fromEntries(res.headers);
+
+	// no static headers config, must expect dynamic value
+	assert.is(headers['Vary'], 'Access-Control-Request-Headers');
+	assert.is(headers['Access-Control-Allow-Headers'], 'Content-Type');
+});
+
+preflight('custom :: origin :: string', () => {
+	let req = Request('OPTIONS');
+	let res = Response();
+
+	CORS.preflight({
+		origin: 'https://foobar.com'
+	})(req, res);
+
+	let headers = Object.fromEntries(res.headers);
+	// no static headers config, must expect dynamic value (append)
+	assert.is(headers['Vary'], 'Origin, Access-Control-Request-Headers');
+	assert.is(headers['Access-Control-Allow-Origin'], 'https://foobar.com');
+	assert.is(headers['Access-Control-Allow-Headers'], undefined);
+});
+
+preflight('custom :: origin :: false ("*")', () => {
+	let req = Request('OPTIONS');
+	let res = Response();
+
+	CORS.preflight({ origin: false })(req, res);
+
+	let headers = Object.fromEntries(res.headers);
+
+	// missing static headers config
+	assert.is(headers['Vary'], 'Access-Control-Request-Headers');
+	assert.is(headers['Access-Control-Allow-Origin'], '*');
+});
+
+preflight('custom :: origin :: true (reflect)', () => {
+	let req = Request('OPTIONS');
+	let res = Response();
+
+	req.headers.set('Origin', 'https://hello.com');
+	CORS.preflight({ origin: true })(req, res);
+
+	let headers = Object.fromEntries(res.headers);
+
+	// missing static headers config
+	assert.is(headers['Vary'], 'Origin, Access-Control-Request-Headers');
+	assert.is(headers['Access-Control-Allow-Origin'], 'https://hello.com');
+});
+
+preflight('custom :: origin :: RegExp (pass)', () => {
+	let req = Request('OPTIONS');
+	let res = Response();
+
+	req.headers.set('Origin', 'https://foobar.com');
+	CORS.preflight({ origin: /foobar/ })(req, res);
+
+	let headers = Object.fromEntries(res.headers);
+
+	// missing static headers config
+	assert.is(headers['Vary'], 'Origin, Access-Control-Request-Headers');
+	assert.is(headers['Access-Control-Allow-Origin'], 'https://foobar.com');
+});
+
+preflight('custom :: origin :: RegExp (fail)', () => {
+	let req = Request('OPTIONS');
+	let res = Response();
+
+	req.headers.set('Origin', 'https://foobar.com');
+	CORS.preflight({ origin: /hello/ })(req, res);
+
+	let headers = Object.fromEntries(res.headers);
+
+	// missing static headers config
+	assert.is(headers['Vary'], 'Origin, Access-Control-Request-Headers');
+	assert.is(headers['Access-Control-Allow-Origin'], 'false');
+});
+
+preflight.run();

--- a/src/cors.ts
+++ b/src/cors.ts
@@ -1,0 +1,57 @@
+import type { Handler } from 'worktop';
+import type { Config } from 'worktop/cors';
+import type { ServerResponse } from 'worktop/response';
+
+export const config: Config = {
+	origin: '*',
+	methods: ['GET', 'HEAD', 'PUT', 'PATCH', 'POST', 'DELETE'],
+	headers: [],
+	expose: [],
+};
+
+// NOTE: Allow `credentials` + `origin:*` to error naturally. Must fix config.
+// @see https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS/Errors/CORSNotSupportingCredentials
+export function headers(res: ServerResponse, options?: Partial<Config>, isPreflight?: boolean) {
+	let opts = (options ? { ...config, ...options } : config) as Required<Config>;
+
+	res.setHeader('Access-Control-Allow-Origin', opts.origin);
+	if (opts.origin !== '*') res.headers.append('Vary', 'Origin');
+	if (opts.credentials) res.setHeader('Access-Control-Allow-Credentials', 'true');
+	if (opts.expose.length) res.setHeader('Access-Control-Expose-Headers', opts.expose);
+
+	if (isPreflight) {
+		if (opts.maxage != null) res.setHeader('Access-Control-Max-Age', opts.maxage);
+		if (opts.methods.length) res.setHeader('Access-Control-Allow-Methods', opts.methods);
+		if (opts.headers.length) res.setHeader('Access-Control-Allow-Headers', opts.headers);
+	}
+}
+
+type Options = Omit<Config, 'origin'> & { origin?: boolean | string | RegExp };
+export function preflight(options: Options = {}): Handler {
+	let origin = (options.origin = options.origin || '*');
+	let isStatic = typeof origin === 'string';
+
+	return function (req, res) {
+		let tmp: string | null;
+		let isPreflight = req.method === 'OPTIONS';
+
+		if (!isStatic) {
+			tmp = req.headers.get('Origin') || '';
+			// false -> "*"; true -> reflects; rgx -> reflect?
+			options.origin = origin === true && tmp || origin instanceof RegExp && origin.test(tmp) && tmp || 'false';
+		}
+
+		headers(res, options as Config, isPreflight);
+
+		if (isPreflight) {
+			if (!options.headers) {
+				tmp = req.headers.get('Access-Control-Request-Headers');
+				if (tmp) res.setHeader('Access-Control-Allow-Headers', tmp);
+				res.headers.append('Vary', 'Access-Control-Request-Headers'); // reflects
+			}
+
+			res.statusCode = 204;
+			res.end(null);
+		}
+	};
+}

--- a/src/request.d.ts
+++ b/src/request.d.ts
@@ -125,6 +125,7 @@ export declare class ServerRequest<P extends Params = Params> {
 	url: string;
 	path: string;
 	method: string;
+	origin: string;
 	hostname: string;
 	search: string;
 	query: URLSearchParams;

--- a/src/request.test.ts
+++ b/src/request.test.ts
@@ -47,6 +47,7 @@ request('should have instance properties', () => {
 	const url = new URL(req.url);
 	assert.is(req.path, url.pathname);
 	assert.is(req.hostname, url.hostname);
+	assert.is(req.origin, url.origin);
 	assert.instance(req.query, URLSearchParams);
 	assert.equal(req.query, url.searchParams);
 	assert.is(req.search, url.search);

--- a/src/request.ts
+++ b/src/request.ts
@@ -15,6 +15,7 @@ export function ServerRequest(this: SR, event: FetchEvent): SR {
 
 	$.path = url.pathname;
 	$.hostname = url.hostname;
+	$.origin = url.origin;
 	$.query = url.searchParams;
 	$.search = url.search;
 

--- a/src/response.d.ts
+++ b/src/response.d.ts
@@ -1,5 +1,6 @@
 /// <reference lib="webworker" />
 
+type Arrayable<T> = T[] | T;
 export type HeadersObject = Record<string, string>;
 
 export declare class ServerResponse {
@@ -18,7 +19,7 @@ export declare class ServerResponse {
 
 	hasHeader(key: string): boolean;
 	getHeader(key: string): string | null;
-	setHeader(key: string, value: string): void;
+	setHeader(key: string, value: Arrayable<string|number>): void;
 	removeHeader(key: string): void;
 
 	writeHead(code: number, headers?: HeadersObject): void;

--- a/src/router.ts
+++ b/src/router.ts
@@ -100,7 +100,6 @@ export function Router(): RR {
 			const req = new ServerRequest(event);
 			const res = new ServerResponse(req.method);
 
-			// TODO: options.cors?
 			if ($.prepare) await $.prepare(req, res);
 			if (res.finished) return new Response(res.body, res);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
       "worktop/response": ["./response.d.ts", "./response.ts"],
       "worktop/cookie": ["./cookie.d.ts", "./cookie.ts"],
       "worktop/utils": ["./utils.d.ts", "./utils.ts"],
+      "worktop/cors": ["./cors.d.ts", "./cors.js"],
       "worktop/kv": ["./kv.d.ts", "./kv.js"],
     }
   },

--- a/types/check.ts
+++ b/types/check.ts
@@ -48,6 +48,18 @@ assert<string | null>(response.getHeader('foo'));
 assert<void>(response.setHeader('foo', 'bar'));
 assert<void>(response.removeHeader('foo'));
 
+// NOTE: native cast to string
+response.setHeader('foo', 123);
+response.setHeader('foo', [123]);
+response.setHeader('foo', ['bar']);
+response.setHeader('foo', 123.45678);
+response.setHeader('foo', ['a', 1, 'b']);
+
+// @ts-expect-error
+response.setHeader('foo', { foo: 123 });
+// @ts-expect-error - altho technically ok
+response.setHeader('foo', new Date);
+
 // @ts-expect-error
 assert<void>(response.writeHead('foo'));
 assert<void>(response.writeHead(200, { foo: 'bar'}));

--- a/types/check.ts
+++ b/types/check.ts
@@ -1,3 +1,4 @@
+import * as CORS from 'worktop/cors';
 import * as Cache from 'worktop/cache';
 import * as Base64 from 'worktop/base64';
 import { Database, until } from 'worktop/kv';
@@ -480,3 +481,32 @@ Base64.encode(12345);
 
 // @ts-expect-error
 Base64.encode(new Uint8Array);
+
+/**
+ * WORKTOP/CORS
+ */
+assert<CORS.Config>(CORS.config);
+assert<string>(CORS.config.origin);
+assert<string[]>(CORS.config.headers!);
+assert<boolean>(CORS.config.credentials!);
+assert<string[]>(CORS.config.methods!);
+assert<string[]>(CORS.config.expose!);
+
+assert<Function>(CORS.headers);
+assert<Function>(CORS.preflight);
+
+declare const request: ServerRequest;
+
+// @ts-expect-error
+CORS.headers(request);
+CORS.headers(response);
+
+CORS.headers(response, {
+	// @ts-expect-error
+	origin: true
+});
+
+// @ts-expect-error
+CORS.preflight(request, response);
+CORS.preflight()(request, response);
+CORS.preflight({ origin: true });

--- a/types/check.ts
+++ b/types/check.ts
@@ -105,6 +105,7 @@ API.add('POST', '/items', async (req, res) => {
 	assert<string>(req.path);
 	assert<object>(req.params);
 	assert<string>(req.hostname);
+	assert<string>(req.origin);
 	assert<string>(req.method);
 	assert<URLSearchParams>(req.query);
 	assert<()=>Promise<unknown>>(req.body);


### PR DESCRIPTION
> Closes #1 

***Example Uses***

```ts
import { Router } from 'worktop';
import * as CORS from 'worktop/cors';
import * as Cache from 'worktop/cache';

const API = new Router();

// Option 1
// Define global CORS handler
API.prepare = CORS.preflight({
  credentials: true,
  maxage: 86400,
  // ... more
});

// Option 2
// Define non-preflight headers globally
API.prepare = function (req, res) {
  CORS.headers(res, {
    credentials: true,
    // (Optional): React to incoming `Origin` header
    origin: req.headers.get('Origin') || 'https://example.com',
    // ... more
  });

  // ... other global logic
};

// Option 3
// Different CORS per "Route Group"
// NOTE: The compose() is TODO
const isDashboardApp = CORS.preflight({ 
  origin: 'https://app.example.com'
});
API.get('/api/*', compose(isDashboardApp, ...));
API.post('/api/*', compose(isDashboardApp, ...));
API.delete('/api/*', compose(isDashboardApp, ...));
API.put('/api/*', compose(isDashboardApp, ...));

// Allow any origin to request "/static/*" URLs
API.get('/static/*', compose(
  CORS.preflight({ 
    maxage: 86400,
    origin: '*',
  }),
  async (req, res) => {
    // Get the file...
  }
));

// Option 4
// Mutate `CORS` defaults
// ~> call with different settings
CORS.config.methods = ['GET', 'POST', 'PUT'];
CORS.config.headers = ['Content-Type', 'Authorization'];
CORS.config.credentials = true;

API.options('/static/*', CORS.preflight());
API.get('/static/*', async (req, res) => {
  CORS.headers(res); // also uses defaults
  // .. do something
});

Cache.listen(API.run);
```

> **Important:** The `compose` utility (#7) is coming next, making per-route/route-group composing much simpler!

***Other Changes***

- Adds `origin` property to all `ServerRequest` instances.
- Fixes `ServerResponse#setHeader` type definition to allow `Arrayable<string | number>` values.