### PR TITLE
feat: add `compose` to main module

### DIFF
--- a/examples/workers/basic/readme.md
+++ b/examples/workers/basic/readme.md
@@ -1,6 +1,6 @@
 # Example: Basic
 
-> [View in Playground](https://cloudflareworkers.com/#168e65c86c627f31e9d026f829c2e828:https://tutorial.cloudflareworkers.com)
+> [View in Playground](https://cloudflareworkers.com/#f4869afcd23f8c5d2267645cf54294ba:https://tutorial.cloudflareworkers.com/)
 
 Defines two `GET` endpoints:
 * `GET /` – displays a welcome message (public cache)

--- a/examples/workers/cors/readme.md
+++ b/examples/workers/cors/readme.md
@@ -1,6 +1,6 @@
 # Example: CORS
 
-> [View in Playground](https://cloudflareworkers.com/#955c634d65e1ebcb97be610f087be973:https://tutorial.cloudflareworkers.com/)
+> [View in Playground](https://cloudflareworkers.com/#a0edd637de1b4c7c7f5db0d073bb1fa8:https://tutorial.cloudflareworkers.com/)
 
 Configures [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) headers for multiple endpoints in this example:
 

--- a/readme.md
+++ b/readme.md
@@ -23,14 +23,14 @@
 
 * Super [lightweight](https://npm.anvaka.com/#/view/2d/worktop)
 * First-class TypeScript support
-* Custom Middleware Support<sup>*</sup>
+* Custom Middleware Support
 * Well-organized submodules for à la carte functionality<sup>*</sup>
 * Includes Router with support for pattern definitions
 * Familiar Request-Response handler API
 * Supports `async`/`await` handlers
 * Fully treeshakable
 
-> <sup>*</sup>_Work In Progress! (ASAP)_
+> <sup>*</sup>_More to come!_
 
 ## Install
 

--- a/src/cors.d.ts
+++ b/src/cors.d.ts
@@ -1,4 +1,4 @@
-import type { ServerRequest } from 'worktop/request';
+import type { ServerRequest, Params } from 'worktop/request';
 import type { ServerResponse } from 'worktop/response';
 
 export interface Config {
@@ -68,4 +68,4 @@ type PreflightConfig = Omit<Config, 'origin'> & {
  * Apply all CORS headers (see `headers` export)
  * Will also handle preflight (aka, OPTIONS) requests.
  */
-export function preflight(options?: PreflightConfig): (req: ServerRequest, res: ServerResponse) => void;
+export function preflight(options?: PreflightConfig): <P extends Params = Params>(req: ServerRequest<P>, res: ServerResponse) => void;

--- a/src/router.d.ts
+++ b/src/router.d.ts
@@ -49,7 +49,7 @@ export declare class Router {
 	find(method: string, pathname: string): Route|void;
 	run(event: FetchEvent): Promise<Response>;
 	onerror(req: ServerRequest, res: ServerResponse, status?: number, error?: Error): Promisable<Response>;
-	prepare?(req: Omit<ServerRequest, 'params'>, res: ServerResponse): Promisable<void>;
+	prepare?(req: Omit<ServerRequest, 'params'>, res: ServerResponse): Promisable<Response|void>;
 }
 
 // TODO?: worktop/status | worktop/errors

--- a/src/router.d.ts
+++ b/src/router.d.ts
@@ -25,7 +25,7 @@ export function reply(handler: ResponseHandler): FetchHandler;
  */
 export function listen(handler: ResponseHandler): void;
 
-export type Route = { params: Params; handler: Handler | false };
+export type Route = { params: Params; handler: Handler };
 export type Handler<P extends Params = Params> = (req: ServerRequest<P>, res: ServerResponse) => Promisable<Response|void>;
 
 export type RouteParams<T extends string> =
@@ -46,8 +46,7 @@ export type RouteParams<T extends string> =
 export declare class Router {
 	add<T extends RegExp>(method: string, route: T, handler: Handler<Params>): void;
 	add<T extends string>(method: string, route: T, handler: Handler<RouteParams<T>>): void;
-
-	find(method: string, pathname: string): Route;
+	find(method: string, pathname: string): Route|void;
 	run(event: FetchEvent): Promise<Response>;
 	onerror(req: ServerRequest, res: ServerResponse, status?: number, error?: Error): Promisable<Response>;
 	prepare?(req: Omit<ServerRequest, 'params'>, res: ServerResponse): Promisable<void>;

--- a/src/router.d.ts
+++ b/src/router.d.ts
@@ -55,3 +55,8 @@ export declare class Router {
 
 // TODO?: worktop/status | worktop/errors
 export declare var STATUS_CODES: Record<string|number, string>;
+
+/**
+ * Compose multiple `Handler` functions together, creating a final handler.
+ */
+export function compose<P extends Params = Params>(...handlers: Handler<P>[]): Handler<P>;

--- a/src/router.ts
+++ b/src/router.ts
@@ -108,8 +108,7 @@ export function Router(): RR {
 			let tmp, req = new ServerRequest(event);
 			const res = new ServerResponse(req.method);
 
-			if ($.prepare) await $.prepare(req, res);
-			if (res.finished) return new Response(res.body, res);
+			if ($.prepare && (tmp = await call($.prepare, false, req, res))) return tmp;
 
 			tmp = $.find(req.method, req.path);
 			if (!tmp) return call($.onerror, true, req, res, 404);

--- a/src/router.ts
+++ b/src/router.ts
@@ -95,8 +95,6 @@ export function Router(): RR {
 					return { params, handler: val.handler };
 				}
 			}
-
-			return { params, handler: false };
 		},
 
 		onerror(req, res, status, error) {
@@ -106,18 +104,18 @@ export function Router(): RR {
 		},
 
 		async run(event) {
-			const req = new ServerRequest(event);
+			let tmp, req = new ServerRequest(event);
 			const res = new ServerResponse(req.method);
 
 			if ($.prepare) await $.prepare(req, res);
 			if (res.finished) return new Response(res.body, res);
 
-			const { params, handler } = $.find(req.method, req.path);
-			if (!handler) return call($.onerror, req, res, 404);
+			tmp = $.find(req.method, req.path);
+			if (!tmp) return call($.onerror, req, res, 404);
 
 			try {
-				req.params = params;
-				return call(handler, req, res);
+				req.params = tmp.params;
+				return call(tmp.handler, req, res);
 			} catch (err) {
 				return call($.onerror, req, res, 500, err);
 			}

--- a/src/router.ts
+++ b/src/router.ts
@@ -19,6 +19,15 @@ export function listen(handler: ResponseHandler): void {
 	addEventListener('fetch', reply(handler));
 }
 
+export function compose(...handlers: Handler[]): Handler {
+	return async function (req, res) {
+		for (let handler of handlers) {
+			let tmp = await handler(req, res);
+			if (tmp instanceof Response) return tmp;
+			if (res.finished) return new Response(res.body, res);
+		}
+	};
+}
 interface Entry {
 	keys: string[];
 	handler: Handler;

--- a/types/check.ts
+++ b/types/check.ts
@@ -172,7 +172,7 @@ API.find('GET', 123);
 // @ts-expect-error
 API.find('GET', /^foo[/]?/);
 
-assert<Route>(
+assert<Route|void>(
 	API.find('GET', '/pathname')
 );
 

--- a/types/check.ts
+++ b/types/check.ts
@@ -374,6 +374,17 @@ API.prepare = function (req, res) {
 // @ts-expect-error - numerical
 API.prepare = (req, res) => 123;
 
+API.add('GET', '/static/:group/*', compose(
+  CORS.preflight({ maxage: 86400 }),
+  async (req, res) => {
+		// @ts-expect-error
+		req.params.foobar // is not defined
+		assert<{ group: string; wild: string }>(req.params);
+		assert<string>(req.params.group);
+		assert<string>(req.params.wild);
+  }
+));
+
 /**
  * WORKTOP/CACHE
  */

--- a/types/check.ts
+++ b/types/check.ts
@@ -4,7 +4,7 @@ import * as Base64 from 'worktop/base64';
 import { Database, until } from 'worktop/kv';
 import { ServerResponse } from 'worktop/response';
 import { byteLength, HEX, uid, uuid } from 'worktop/utils';
-import { listen, reply, Router, STATUS_CODES } from 'worktop';
+import { listen, reply, Router, compose, STATUS_CODES } from 'worktop';
 
 import type { KV } from 'worktop/kv';
 import type { UID, UUID } from 'worktop/utils';
@@ -336,6 +336,25 @@ API.add('GET', /^[/]foobar[/]?/, (req) => {
 	assert<string>(req.params.anything);
 });
 
+/**
+ * WORKTOP/ROUTER
+ * > COMPOSE
+ */
+
+API.add('GET', '/foo/:bar?', compose(
+	(req, res) => {
+		assert<string|void>(req.params.bar);
+	},
+	async (req, res) => {
+		assert<string|void>(req.params.bar);
+		res.end('hello');
+	},
+	// @ts-expect-error
+	(req, res) => {
+		assert<string|void>(req.params.bar);
+		return 123;
+	}
+));
 
 /**
  * WORKTOP/CACHE

--- a/types/check.ts
+++ b/types/check.ts
@@ -356,6 +356,24 @@ API.add('GET', '/foo/:bar?', compose(
 	}
 ));
 
+// Can be a Handler
+API.prepare = compose(
+	(req, res) => {},
+	(req, res) => {},
+	(req, res) => {},
+);
+
+// Can be a Handler
+API.prepare = function (req, res) {
+	// @ts-expect-error
+	req.params; // does not exist
+	// can now return Response instance~!
+	return new Response(null, { status: 204 });
+}
+
+// @ts-expect-error - numerical
+API.prepare = (req, res) => 123;
+
 /**
  * WORKTOP/CACHE
  */


### PR DESCRIPTION
This _implements_ but #7 – but this PR _does not_ bring the strict type-safety that I was hoping to add. I figure it's better to add the utility for now & comb through later once I've been able to add the explicit inference(s) I wanted to make.

This PR also makes "Option 3" of #22 possible.