### PR TITLE
feat: add conditional `require` exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "esbuild": "0.9.2",
     "is-uuid": "1.0.2",
     "kleur": "4.1.4",
+    "rewrite-imports": "2.0.3",
     "typescript": "4.2.3",
     "uvu": "0.5.1"
   },

--- a/package.json
+++ b/package.json
@@ -12,16 +12,46 @@
     "url": "https://lukeed.com"
   },
   "exports": {
-    ".": "./router/index.mjs",
-    "./kv": "./kv/index.mjs",
-    "./cors": "./cors/index.mjs",
-    "./cache": "./cache/index.mjs",
-    "./cookie": "./cookie/index.mjs",
-    "./crypto": "./crypto/index.mjs",
-    "./request": "./request/index.mjs",
-    "./response": "./response/index.mjs",
-    "./base64": "./base64/index.mjs",
-    "./utils": "./utils/index.mjs",
+    ".": {
+      "import": "./router/index.mjs",
+      "require": "./router/index.js"
+    },
+    "./kv": {
+      "import": "./kv/index.mjs",
+      "require": "./kv/index.js"
+    },
+    "./cors": {
+      "import": "./cors/index.mjs",
+      "require": "./cors/index.js"
+    },
+    "./cache": {
+      "import": "./cache/index.mjs",
+      "require": "./cache/index.js"
+    },
+    "./cookie": {
+      "import": "./cookie/index.mjs",
+      "require": "./cookie/index.js"
+    },
+    "./crypto": {
+      "import": "./crypto/index.mjs",
+      "require": "./crypto/index.js"
+    },
+    "./request": {
+      "import": "./request/index.mjs",
+      "require": "./request/index.js"
+    },
+    "./response": {
+      "import": "./response/index.mjs",
+      "require": "./response/index.js"
+    },
+    "./base64": {
+      "import": "./base64/index.mjs",
+      "require": "./base64/index.js"
+    },
+    "./utils": {
+      "import": "./utils/index.mjs",
+      "require": "./utils/index.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [


### PR DESCRIPTION
Adds conditional support for CommonJS via `require` statements.

Ideally, worktop will revert back to a _pure_ ESM module. This is (still) blocked by the Node.js `--loader` hook being experimental. And, relatedly, all/most test runners not being able to support native ESM _and_ TypeScript at the same time since `--require` hooks are all that's currently available.

> **Note:** You can manually get this working, see https://github.com/lukeed/worktop/issues/27#issuecomment-822737438<br>However, note that the solution there is (currently) missing sourcemap support... easy to fix.

In any event, worktop cannot assume or force a particular testing setup. So, given that it encourages TS adoption, it should _offer_ (not encourage) CommonJS format for **testing purposes**.

> **Important:** Always use `import` in your application source! All bundlers have **much better** tree-shaking with ESM.

---

Closes #27
Closes #31 