### PR TITLE
feat: allow multi-method route

### DIFF
--- a/src/router.d.ts
+++ b/src/router.d.ts
@@ -3,6 +3,8 @@
 import type { ServerResponse } from 'worktop/response';
 import type { ServerRequest, Params } from 'worktop/request';
 
+export type Method = string;
+
 type Promisable<T> = Promise<T> | T;
 
 export type FetchHandler = (event: FetchEvent) => void;
@@ -44,7 +46,7 @@ export type RouteParams<T extends string> =
 	: {};
 
 export declare class Router {
-	add<T extends RegExp>(method: string, route: T, handler: Handler<Params>): void;
+	add<T extends RegExp>(method: Method | Method[], route: T, handler: Handler<Params>): void;
 	add<T extends string>(method: string, route: T, handler: Handler<RouteParams<T>>): void;
 	find(method: string, pathname: string): Route|void;
 	run(event: FetchEvent): Promise<Response>;

--- a/src/router.ts
+++ b/src/router.ts
@@ -52,23 +52,27 @@ export function Router(): RR {
 	let $: RR, tree: Tree = {};
 
 	return $ = {
-		add(method: string, route: RegExp | string, handler: Handler) {
-			let dict = tree[method];
+		add(method: Method | Method[], route: RegExp | string, handler: Handler) {
+			const methods = Array.isArray(method) ? method: [method];
 
-			if (dict === void 0) {
-				dict = tree[method] = {
-					__d: new Map,
-					__s: {},
-				};
-			}
+			for (const method of methods) {
+				let dict = tree[method];
 
-			if (route instanceof RegExp) {
-				dict.__d.set(route, { keys:[], handler });
-			} else if (/[:|*]/.test(route)) {
-				const { keys, pattern } = regexparam(route);
-				dict.__d.set(pattern, { keys, handler });
-			} else {
-				dict.__s[route] = { keys:[], handler };
+				if (dict === void 0) {
+					dict = tree[method] = {
+						__d: new Map,
+						__s: {},
+					};
+				}
+
+				if (route instanceof RegExp) {
+					dict.__d.set(route, { keys:[], handler });
+				} else if (/[:|*]/.test(route)) {
+					const { keys, pattern } = regexparam(route);
+					dict.__d.set(pattern, { keys, handler });
+				} else {
+					dict.__s[route] = { keys:[], handler };
+				}
 			}
 		},
 


### PR DESCRIPTION
use case example:

```ts
API.add(['GET', 'POST'], '/graphql', handleGraphQL);
```