### PR TITLE
chore: type inference for HTTP method

### DIFF
--- a/src/request.d.ts
+++ b/src/request.d.ts
@@ -112,11 +112,11 @@ export interface IncomingCloudflareProperties {
 	timezone: string;
 }
 
-export declare class ServerRequest<P extends Params = Params, M extends Method = Method> {
+export declare class ServerRequest<P extends Params = Params> {
 	constructor(event: FetchEvent);
 	url: string;
 	path: string;
-	method: M;
+	method: Method;
 	origin: string;
 	hostname: string;
 	search: string;

--- a/src/request.d.ts
+++ b/src/request.d.ts
@@ -8,20 +8,7 @@ declare global {
 
 export type Params = Record<string, string>;
 
-export type Method = (
-	| 'GET'
-	| 'HEAD'
-	| 'POST'
-	| 'PUT'
-	| 'DELETE'
-	| 'CONNECT'
-	| 'OPTIONS'
-	| 'TRACE'
-
-	// https://tools.ietf.org/html/rfc5789#section-2
-	| 'PATCH'
-);
-
+export type Method = 'GET' | 'HEAD' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'CONNECT' | 'OPTIONS' | 'TRACE';
 /** @see https://developers.cloudflare.com/workers/runtime-apis/request#incomingrequestcfproperties */
 export interface IncomingCloudflareProperties {
 	/**

--- a/src/request.d.ts
+++ b/src/request.d.ts
@@ -9,7 +9,7 @@ declare global {
 export type Params = Record<string, string>;
 
 /** @see {require('http').METHODS} */
-export type Method = 'ACL' | 'BIND' | 'CHECKOUT' | 'CONNECT' | 'COPY' | 'DELETE' | 'GET' | 'HEAD' | 'LINK' | 'LOCK' |'M-SEARCH' | 'MERGE' | 'MKACTIVITY' |'MKCALENDAR' | 'MKCOL' | 'MOVE' |'NOTIFY' | 'OPTIONS' | 'PATCH' | 'POST' | 'PRI' | 'PROPFIND' |  'PROPPATCH' |  'PURGE' | 'PUT' | 'REBIND' | 'REPORT' | 'SEARCH' | 'SOURCE' | 'SUBSCRIBE' | 'TRACE' | 'UNBIND' | 'UNLINK' | 'UNLOCK' | 'UNSUBSCRIBE';
+export type Method = 'ACL' | 'BIND' | 'CHECKOUT' | 'CONNECT' | 'COPY' | 'DELETE' | 'GET' | 'HEAD' | 'LINK' | 'LOCK' | 'M-SEARCH' | 'MERGE' | 'MKACTIVITY' | 'MKCALENDAR' | 'MKCOL' | 'MOVE' | 'NOTIFY' | 'OPTIONS' | 'PATCH' | 'POST' | 'PRI' | 'PROPFIND' | 'PROPPATCH' | 'PURGE' | 'PUT' | 'REBIND' | 'REPORT' | 'SEARCH' | 'SOURCE' | 'SUBSCRIBE' | 'TRACE' | 'UNBIND' | 'UNLINK' | 'UNLOCK' | 'UNSUBSCRIBE';
 
 /** @see https://developers.cloudflare.com/workers/runtime-apis/request#incomingrequestcfproperties */
 export interface IncomingCloudflareProperties {

--- a/src/request.d.ts
+++ b/src/request.d.ts
@@ -9,6 +9,7 @@ declare global {
 export type Params = Record<string, string>;
 
 export type Method = 'GET' | 'HEAD' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'CONNECT' | 'OPTIONS' | 'TRACE';
+
 /** @see https://developers.cloudflare.com/workers/runtime-apis/request#incomingrequestcfproperties */
 export interface IncomingCloudflareProperties {
 	/**

--- a/src/request.d.ts
+++ b/src/request.d.ts
@@ -8,6 +8,20 @@ declare global {
 
 export type Params = Record<string, string>;
 
+export type Method = (
+	| 'GET'
+	| 'HEAD'
+	| 'POST'
+	| 'PUT'
+	| 'DELETE'
+	| 'CONNECT'
+	| 'OPTIONS'
+	| 'TRACE'
+
+	// https://tools.ietf.org/html/rfc5789#section-2
+	| 'PATCH'
+);
+
 /** @see https://developers.cloudflare.com/workers/runtime-apis/request#incomingrequestcfproperties */
 export interface IncomingCloudflareProperties {
 	/**
@@ -111,11 +125,11 @@ export interface IncomingCloudflareProperties {
 	timezone: string;
 }
 
-export declare class ServerRequest<P extends Params = Params> {
+export declare class ServerRequest<P extends Params = Params, M extends Method = Method> {
 	constructor(event: FetchEvent);
 	url: string;
 	path: string;
-	method: string;
+	method: M;
 	origin: string;
 	hostname: string;
 	search: string;

--- a/src/request.d.ts
+++ b/src/request.d.ts
@@ -8,6 +8,7 @@ declare global {
 
 export type Params = Record<string, string>;
 
+/** @see {require('http').METHODS} */
 export type Method = 'GET' | 'HEAD' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'CONNECT' | 'OPTIONS' | 'TRACE';
 
 /** @see https://developers.cloudflare.com/workers/runtime-apis/request#incomingrequestcfproperties */

--- a/src/request.d.ts
+++ b/src/request.d.ts
@@ -9,7 +9,7 @@ declare global {
 export type Params = Record<string, string>;
 
 /** @see {require('http').METHODS} */
-export type Method = 'GET' | 'HEAD' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'CONNECT' | 'OPTIONS' | 'TRACE';
+export type Method = 'ACL' | 'BIND' | 'CHECKOUT' | 'CONNECT' | 'COPY' | 'DELETE' | 'GET' | 'HEAD' | 'LINK' | 'LOCK' |'M-SEARCH' | 'MERGE' | 'MKACTIVITY' |'MKCALENDAR' | 'MKCOL' | 'MOVE' |'NOTIFY' | 'OPTIONS' | 'PATCH' | 'POST' | 'PRI' | 'PROPFIND' |  'PROPPATCH' |  'PURGE' | 'PUT' | 'REBIND' | 'REPORT' | 'SEARCH' | 'SOURCE' | 'SUBSCRIBE' | 'TRACE' | 'UNBIND' | 'UNLINK' | 'UNLOCK' | 'UNSUBSCRIBE';
 
 /** @see https://developers.cloudflare.com/workers/runtime-apis/request#incomingrequestcfproperties */
 export interface IncomingCloudflareProperties {

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,5 +1,5 @@
 import { body } from './internal/request';
-import type { ServerRequest as SR } from 'worktop/request';
+import type { ServerRequest as SR, Method } from 'worktop/request';
 
 export function ServerRequest(this: SR, event: FetchEvent): SR {
 	const { request, waitUntil } = event;
@@ -7,7 +7,7 @@ export function ServerRequest(this: SR, event: FetchEvent): SR {
 	const $ = this;
 
 	$.url = request.url;
-	$.method = request.method;
+	$.method = request.method as Method;
 	$.headers = request.headers;
 	$.extend = waitUntil;
 	$.cf = request.cf;

--- a/src/router.d.ts
+++ b/src/router.d.ts
@@ -1,7 +1,7 @@
 /// <reference lib="webworker" />
 
 import type { ServerResponse } from 'worktop/response';
-import type { ServerRequest, Params } from 'worktop/request';
+import type { ServerRequest, Params, Method } from 'worktop/request';
 
 type Promisable<T> = Promise<T> | T;
 
@@ -26,7 +26,7 @@ export function reply(handler: ResponseHandler): FetchHandler;
 export function listen(handler: ResponseHandler): void;
 
 export type Route = { params: Params; handler: Handler };
-export type Handler<P extends Params = Params> = (req: ServerRequest<P>, res: ServerResponse) => Promisable<Response|void>;
+export type Handler<P extends Params = Params, M extends Method = Method> = (req: ServerRequest<P, M>, res: ServerResponse) => Promisable<Response|void>;
 
 export type RouteParams<T extends string> =
 	T extends `${infer Prev}/*/${infer Rest}`
@@ -44,9 +44,9 @@ export type RouteParams<T extends string> =
 	: {};
 
 export declare class Router {
-	add<T extends RegExp>(method: string, route: T, handler: Handler<Params>): void;
-	add<T extends string>(method: string, route: T, handler: Handler<RouteParams<T>>): void;
-	find(method: string, pathname: string): Route|void;
+	add<T extends RegExp, M extends Method>(method: M, route: T, handler: Handler<Params, M>): void;
+	add<T extends string, M extends Method>(method: M, route: T, handler: Handler<RouteParams<T>, M>): void;
+	find(method: Method, pathname: string): Route|void;
 	run(event: FetchEvent): Promise<Response>;
 	onerror(req: ServerRequest, res: ServerResponse, status?: number, error?: Error): Promisable<Response>;
 	prepare?(req: Omit<ServerRequest, 'params'>, res: ServerResponse): Promisable<Response|void>;

--- a/src/router.d.ts
+++ b/src/router.d.ts
@@ -45,7 +45,7 @@ export type RouteParams<T extends string> =
 
 export declare class Router {
 	add<T extends RegExp, M extends Method>(method: M, route: T, handler: Handler<Params, M>): void;
-	add<T extends string, M extends Method>(method: M, route: T, handler: Handler<RouteParams<T>, M>): void;
+	add<T extends string>(method: Method, route: T, handler: Handler<RouteParams<T>>): void;
 	find(method: Method, pathname: string): Route|void;
 	run(event: FetchEvent): Promise<Response>;
 	onerror(req: ServerRequest, res: ServerResponse, status?: number, error?: Error): Promisable<Response>;

--- a/src/router.d.ts
+++ b/src/router.d.ts
@@ -26,7 +26,7 @@ export function reply(handler: ResponseHandler): FetchHandler;
 export function listen(handler: ResponseHandler): void;
 
 export type Route = { params: Params; handler: Handler };
-export type Handler<P extends Params = Params, M extends Method = Method> = (req: ServerRequest<P, M>, res: ServerResponse) => Promisable<Response|void>;
+export type Handler<P extends Params = Params> = (req: ServerRequest<P>, res: ServerResponse) => Promisable<Response|void>;
 
 export type RouteParams<T extends string> =
 	T extends `${infer Prev}/*/${infer Rest}`
@@ -44,7 +44,7 @@ export type RouteParams<T extends string> =
 	: {};
 
 export declare class Router {
-	add<T extends RegExp, M extends Method>(method: M, route: T, handler: Handler<Params, M>): void;
+	add<T extends RegExp>(method: Method, route: T, handler: Handler<Params>): void;
 	add<T extends string>(method: Method, route: T, handler: Handler<RouteParams<T>>): void;
 	find(method: Method, pathname: string): Route|void;
 	run(event: FetchEvent): Promise<Response>;

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,11 +1,11 @@
 import regexparam from 'regexparam';
-import { ServerRequest, Method } from 'worktop/request';
+import { ServerRequest } from 'worktop/request';
 import { ServerResponse } from 'worktop/response';
 import { STATUS_CODES } from './internal/constants';
 
 import type { FetchHandler, ResponseHandler } from 'worktop';
 import type { Handler, Router as RR } from 'worktop';
-import type { Params } from 'worktop/request';
+import type { Method, Params } from 'worktop/request';
 
 export { STATUS_CODES };
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,5 +1,5 @@
 import regexparam from 'regexparam';
-import { ServerRequest } from 'worktop/request';
+import { ServerRequest, Method } from 'worktop/request';
 import { ServerResponse } from 'worktop/response';
 import { STATUS_CODES } from './internal/constants';
 
@@ -36,8 +36,7 @@ interface Branch {
 	__s: Record<string, Entry>;
 }
 
-type Method = string;
-type Tree = Record<Method, Branch>;
+type Tree = Partial<Record<Method, Branch>>;
 
 async function call(fn: Function, isEnd: true, req: ServerRequest, res: ServerResponse, ...args: any[]): Promise<Response>;
 async function call(fn: Function, isEnd: false, req: ServerRequest, res: ServerResponse, ...args: any[]): Promise<Response|void>;
@@ -52,7 +51,7 @@ export function Router(): RR {
 	let $: RR, tree: Tree = {};
 
 	return $ = {
-		add(method: string, route: RegExp | string, handler: Handler) {
+		add(method: Method, route: RegExp | string, handler: Handler) {
 			let dict = tree[method];
 
 			if (dict === void 0) {


### PR DESCRIPTION
I modified the type definition so that the passed method can be inferred and auto-completed while respecting the existing signature as much as possible.