### PR TITLE
feat(utils): add ArrayBuffer & TypedArray equality checks

### DIFF
--- a/src/utils.d.ts
+++ b/src/utils.d.ts
@@ -81,9 +81,16 @@ export function byteLength(input?: string): number;
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray
  */
 export type TypedArray = Int8Array | Uint8Array | Uint8ClampedArray | Int16Array | Uint16Array | Int32Array | Uint32Array | Float32Array | Float64Array | BigInt64Array | BigUint64Array;
+export type ArrayBufferPure<T extends ArrayBuffer> = T extends TypedArray ? never : T;
 
 /**
  * Check if two `TypedArray` inputs are equal.
  * @NOTE See `isArrayBufferEqual` for raw `ArrayBuffer` instances.
  */
 export function isTypedArrayEqual(a: TypedArray, b: TypedArray): boolean;
+
+/**
+ * Check if two `ArrayBuffer` inputs are equal.
+ * @NOTE See `isTypedArrayEqual` if already have TypedArray instances.
+ */
+export function isArrayBufferEqual<A extends ArrayBuffer, B extends ArrayBuffer>(a: ArrayBufferPure<A>, b: ArrayBufferPure<B>): boolean;

--- a/src/utils.d.ts
+++ b/src/utils.d.ts
@@ -75,3 +75,15 @@ export function decode(input: ArrayBufferView | ArrayBuffer, isStream?: boolean)
  * @param {string} [input]
  */
 export function byteLength(input?: string): number;
+
+/**
+ * Convenient alias for all TypedArray classes
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray
+ */
+export type TypedArray = Int8Array | Uint8Array | Uint8ClampedArray | Int16Array | Uint16Array | Int32Array | Uint32Array | Float32Array | Float64Array | BigInt64Array | BigUint64Array;
+
+/**
+ * Check if two `TypedArray` inputs are equal.
+ * @NOTE See `isArrayBufferEqual` for raw `ArrayBuffer` instances.
+ */
+export function isTypedArrayEqual(a: TypedArray, b: TypedArray): boolean;

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -367,3 +367,62 @@ decode('should return decoded values', () => {
 });
 
 decode.run();
+
+// ---
+
+const isTypedArrayEqual = suite('isTypedArrayEqual');
+
+isTypedArrayEqual('should be a function', () => {
+	assert.type(utils.isTypedArrayEqual, 'function');
+});
+
+isTypedArrayEqual('true :: compare to self', () => {
+	let input = new Uint8Array([1, 2, 3, 4, 5]);
+	assert.ok(utils.isTypedArrayEqual(input, input));
+});
+
+isTypedArrayEqual('true :: compare to clone', () => {
+	let raw = [1, 2, 3, 4, 5];
+	let result = utils.isTypedArrayEqual(
+		new Uint8Array(raw), new Uint8Array(raw),
+	);
+	assert.is(result, true);
+});
+
+isTypedArrayEqual('false :: byteLength', () => {
+	assert.not.ok(
+		utils.isTypedArrayEqual(
+			new Uint8Array(1),
+			new Uint8Array(12)
+		)
+	);
+});
+
+isTypedArrayEqual('false :: constructor', () => {
+	let raw = [1, 2, 3];
+
+	assert.not.ok(
+		utils.isTypedArrayEqual(
+			new Uint8Array(raw),
+			new Uint16Array(raw)
+		)
+	);
+
+	assert.not.ok(
+		utils.isTypedArrayEqual(
+			new Int8Array(raw),
+			new Uint8Array(raw)
+		)
+	);
+});
+
+isTypedArrayEqual('false :: values', () => {
+	assert.not.ok(
+		utils.isTypedArrayEqual(
+			new Uint8Array([1, 2, 3]),
+			new Uint8Array([1, 2, 5])
+		)
+	);
+});
+
+isTypedArrayEqual.run();

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -426,3 +426,98 @@ isTypedArrayEqual('false :: values', () => {
 });
 
 isTypedArrayEqual.run();
+
+// ---
+
+const isArrayBufferEqual = suite('isArrayBufferEqual');
+
+isArrayBufferEqual('should be a function', () => {
+	assert.type(utils.isArrayBufferEqual, 'function');
+});
+
+isArrayBufferEqual('true :: compare to self', () => {
+	let input = new Uint8Array([1, 2, 3, 4, 5]);
+	assert.ok(
+		utils.isArrayBufferEqual(
+			input.buffer,
+			input.buffer
+		)
+	);
+});
+
+isArrayBufferEqual('true :: compare to clone', () => {
+	assert.ok(
+		utils.isArrayBufferEqual(
+			new Uint8Array([1, 2, 3, 4, 5]).buffer,
+			new Uint8Array([1, 2, 3, 4, 5]).buffer
+		)
+	);
+
+	assert.ok(
+		utils.isArrayBufferEqual(
+			new Int8Array([1, 2, 3, 4, 5]).buffer,
+			new Uint8Array([1, 2, 3, 4, 5]).buffer
+		)
+	);
+});
+
+isArrayBufferEqual('true :: empty values', () => {
+	let input = new Int16Array(2);
+	assert.is(input.byteLength, 4);
+	assert.is(input.length, 2);
+
+	assert.ok(
+		utils.isArrayBufferEqual(
+			input.buffer,
+			new ArrayBuffer(4)
+		)
+	);
+
+	assert.ok(
+		utils.isArrayBufferEqual(
+			new ArrayBuffer(1),
+			new ArrayBuffer(1)
+		)
+	);
+
+	assert.ok(
+		utils.isArrayBufferEqual(
+			new Uint8Array(2).buffer,
+			new ArrayBuffer(2)
+		)
+	);
+});
+
+isArrayBufferEqual('false :: byteLength', () => {
+	assert.not.ok(
+		utils.isArrayBufferEqual(
+			new Uint8Array(4).buffer,
+			new Uint8Array(12).buffer,
+		)
+	);
+
+	assert.not.ok(
+		utils.isArrayBufferEqual(
+			new ArrayBuffer(4),
+			new ArrayBuffer(12),
+		)
+	);
+
+	assert.not.ok(
+		utils.isArrayBufferEqual(
+			new Uint8Array([1, 2, 3]).buffer,
+			new Uint32Array([1, 2, 3]).buffer,
+		)
+	);
+});
+
+isArrayBufferEqual('false :: values', () => {
+	assert.not.ok(
+		utils.isArrayBufferEqual(
+			new Uint8Array([1, 2, 3]).buffer,
+			new Uint8Array([1, 2, 5]).buffer,
+		)
+	);
+});
+
+isArrayBufferEqual.run();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -93,3 +93,12 @@ export function isTypedArrayEqual(a: TypedArray, b: TypedArray): boolean {
 	}
 	return true;
 }
+
+// @see https://v8.dev/blog/dataview
+export function isArrayBufferEqual<A extends ArrayBuffer, B extends ArrayBuffer>(a: ArrayBufferPure<A>, b: ArrayBufferPure<B>): boolean {
+	if (a.byteLength !== b.byteLength) return false;
+	for (let i=0, aaa=new DataView(a), bbb=new DataView(b); i < aaa.byteLength; i++) {
+		if (aaa.getUint8(i) !== bbb.getUint8(i)) return false;
+	}
+	return true;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import type { TypedArray, ArrayBufferPure } from 'worktop/utils';
+
 // All 256 hexadecimal pairs (max index = 255)
 // @see https://esbench.com/bench/60555d036c89f600a570049d
 export const HEX = /*#__PURE__*/ ['00', '01', '02', '03', '04', '05', '06', '07', '08', '09', '0a', '0b', '0c', '0d', '0e', '0f', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', '1a', '1b', '1c', '1d', '1e', '1f', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '2a', '2b', '2c', '2d', '2e', '2f', '30', '31', '32', '33', '34', '35', '36', '37', '38', '39', '3a', '3b', '3c', '3d', '3e', '3f', '40', '41', '42', '43', '44', '45', '46', '47', '48', '49', '4a', '4b', '4c', '4d', '4e', '4f', '50', '51', '52', '53', '54', '55', '56', '57', '58', '59', '5a', '5b', '5c', '5d', '5e', '5f', '60', '61', '62', '63', '64', '65', '66', '67', '68', '69', '6a', '6b', '6c', '6d', '6e', '6f', '70', '71', '72', '73', '74', '75', '76', '77', '78', '79', '7a', '7b', '7c', '7d', '7e', '7f', '80', '81', '82', '83', '84', '85', '86', '87', '88', '89', '8a', '8b', '8c', '8d', '8e', '8f', '90', '91', '92', '93', '94', '95', '96', '97', '98', '99', '9a', '9b', '9c', '9d', '9e', '9f', 'a0', 'a1', 'a2', 'a3', 'a4', 'a5', 'a6', 'a7', 'a8', 'a9', 'aa', 'ab', 'ac', 'ad', 'ae', 'af', 'b0', 'b1', 'b2', 'b3', 'b4', 'b5', 'b6', 'b7', 'b8', 'b9', 'ba', 'bb', 'bc', 'bd', 'be', 'bf', 'c0', 'c1', 'c2', 'c3', 'c4', 'c5', 'c6', 'c7', 'c8', 'c9', 'ca', 'cb', 'cc', 'cd', 'ce', 'cf', 'd0', 'd1', 'd2', 'd3', 'd4', 'd5', 'd6', 'd7', 'd8', 'd9', 'da', 'db', 'dc', 'dd', 'de', 'df', 'e0', 'e1', 'e2', 'e3', 'e4', 'e5', 'e6', 'e7', 'e8', 'e9', 'ea', 'eb', 'ec', 'ed', 'ee', 'ef', 'f0', 'f1', 'f2', 'f3', 'f4', 'f5', 'f6', 'f7', 'f8', 'f9', 'fa', 'fb', 'fc', 'fd', 'fe', 'ff'];
@@ -81,4 +83,13 @@ export const decode = (input: ArrayBufferView | ArrayBuffer, stream = false) => 
 
 export function byteLength(input?: string): number {
 	return input ? Encoder.encode(input).byteLength : 0;
+}
+
+export function isTypedArrayEqual(a: TypedArray, b: TypedArray): boolean {
+	if (a.byteLength !== b.byteLength) return false;
+	if (a.constructor !== b.constructor) return false;
+	for (let len = a.length; len-- > 0;) {
+		if (a[len] !== b[len]) return false;
+	}
+	return true;
 }

--- a/types/check.ts
+++ b/types/check.ts
@@ -5,6 +5,7 @@ import { Database, until } from 'worktop/kv';
 import { ServerResponse } from 'worktop/response';
 import { byteLength, HEX, uid, uuid, ulid, randomize } from 'worktop/utils';
 import { listen, reply, Router, compose, STATUS_CODES } from 'worktop';
+import { isTypedArrayEqual } from 'worktop/utils';
 
 import type { KV } from 'worktop/kv';
 import type { UID, UUID, ULID } from 'worktop/utils';
@@ -545,6 +546,20 @@ assert<Uint8Array>(randomize(11));
 assert<Uint8Array>(randomize());
 // @ts-expect-error
 assert<Uint32Array>(randomize(1));
+
+declare let i8: Int8Array;
+declare let u8: Uint8Array;
+declare let u32: Uint32Array;
+declare let ab: ArrayBuffer;
+declare let dv: DataView;
+
+assert<boolean>(isTypedArrayEqual(i8, u8));
+assert<boolean>(isTypedArrayEqual(u32, i8));
+assert<boolean>(isTypedArrayEqual(u32, i8));
+// @ts-expect-error - DataView
+isTypedArrayEqual(u8, dv);
+// @ts-expect-error - ArrayBuffer
+isTypedArrayEqual(ab, i8);
 
 /**
  * WORKTOP/BASE64

--- a/types/check.ts
+++ b/types/check.ts
@@ -5,7 +5,7 @@ import { Database, until } from 'worktop/kv';
 import { ServerResponse } from 'worktop/response';
 import { byteLength, HEX, uid, uuid, ulid, randomize } from 'worktop/utils';
 import { listen, reply, Router, compose, STATUS_CODES } from 'worktop';
-import { isTypedArrayEqual } from 'worktop/utils';
+import { isTypedArrayEqual, isArrayBufferEqual } from 'worktop/utils';
 
 import type { KV } from 'worktop/kv';
 import type { UID, UUID, ULID } from 'worktop/utils';
@@ -560,6 +560,16 @@ assert<boolean>(isTypedArrayEqual(u32, i8));
 isTypedArrayEqual(u8, dv);
 // @ts-expect-error - ArrayBuffer
 isTypedArrayEqual(ab, i8);
+
+assert<boolean>(isArrayBufferEqual(ab, ab));
+isArrayBufferEqual(i8.buffer, u32.buffer);
+isArrayBufferEqual(dv.buffer, ab);
+// @ts-expect-error - DataView
+isArrayBufferEqual(ab, dv);
+// @ts-expect-error - Int8Array
+isArrayBufferEqual(ab, i8);
+// @ts-expect-error - TypedArrays
+isArrayBufferEqual(u32, i8);
 
 /**
  * WORKTOP/BASE64


### PR DESCRIPTION
All of this really just shows me that the `ArrayBuffer` library definitions are bad/too loose. By default, they allow any TypedArray to satisfy the `ArrayBuffer` constraint. This is a big deal because they are completely different _kinds_ of things. `ArrayBuffer`s themselves are inert raw data. You can't do anything with them. They need be accessed/manipulated via a TypedArray interface or a `DataView`.

More practically, this problem shows up with something like:

```ts
new DataView(
  new Uint8Array(12)
);
```

This throws a TypeError, but TypeScript – even with strict mode – says this is perfectly valid.

---

Rant aside, this closes #34.

Use `isArrayBufferEqual` when dealing with raw `ArrayBuffer` instances.
Use `isTypedArrayEqual` when already dealing with a TypedArray instance.