### PR TITLE
fix(cache): handle `HEAD` method correctly

### DIFF
--- a/src/cache.test.ts
+++ b/src/cache.test.ts
@@ -184,10 +184,24 @@ save('should treat custom `request`-string as GET', () => {
 	assert.is(waited, 1);
 });
 
-save('should not save Response if not GET|HEAD method', () => {
+save('should not save Response if not GET method :: POST', () => {
 	let waited=0, saved=0;
 	const res = new Response();
 	const request = { method: 'POST' };
+	const event: any = { request, waitUntil: () => waited=1 };
+	Storage.put = () => saved=1;
+
+	const output = Cache.save(event, res);
+	assert.ok(output === res);
+
+	assert.is(saved, 0);
+	assert.is(waited, 0);
+});
+
+save('should not save Response if not GET method :: HEAD', () => {
+	let waited=0, saved=0;
+	const res = new Response();
+	const request = { method: 'HEAD' };
 	const event: any = { request, waitUntil: () => waited=1 };
 	Storage.put = () => saved=1;
 

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -3,8 +3,14 @@ import type { ResponseHandler } from 'worktop/cache';
 
 export const Cache: Cache = /*#__PURE__*/ (caches as any).default;
 
-export function lookup(event: FetchEvent, request?: Request | string) {
-	return Cache.match(request || event.request);
+export async function lookup(event: FetchEvent, request?: Request | string) {
+	let req = request || event.request;
+	let isHEAD = typeof req !== 'string' && req.method === 'HEAD';
+	if (isHEAD) req = new Request(req, { method: 'GET' });
+
+	let res = await Cache.match(req);
+	if (isHEAD && res) res = new Response(null, res);
+	return res;
 }
 
 export function save(event: FetchEvent, res: Response, request?: Request | string) {

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -9,7 +9,7 @@ export function lookup(event: FetchEvent, request?: Request | string) {
 
 export function save(event: FetchEvent, res: Response, request?: Request | string) {
 	const req = request || event.request;
-	const isGET = typeof req === 'string' || /^(GET|HEAD)$/.test(req.method);
+	const isGET = typeof req === 'string' || req.method === 'GET';
 
 	if (isGET && isCacheable(res)) {
 		if (res.headers.has('Set-Cookie')) {


### PR DESCRIPTION
Could have sworn that, at least at one point, `Cache.put` accepted `HEAD` requests. That, or I ported over broken code from a production app 😬  (TODO: check)

Also added some extra conditions to worktop's `lookup` method so that `HEAD` requests will match its `GET` counterpart. This should have been in place already,  but at the time I sorta just hand-waved it away & assumed that it wouldn't be a huge deal to recompute the underlying `GET` ... but it definitely _could_ be, depending on the route handler!

```js
API.add('GET', '/articles', async (req, res) => {
  // heavy DB query processing, etc
  const items = await expensive('task');
  res.send(200, items);
});

// BEFORE
// ---
// request -> "GET /articles"  -> Cache MISS -> execute -> Cache PUT -> Response
// request -> "GET /articles"  -> Cache HIT  -> Response
// request -> "HEAD /articles" -> Cache HIT  -> execute -> Cache PUT -> Response

// AFTER
// ---
// request -> "GET /articles"  -> Cache MISS -> execute -> Cache PUT -> Response
// request -> "GET /articles"  -> Cache HIT  -> Response
// request -> "HEAD /articles" -> Cache HIT  -> Response
```