### PR TITLE
feat: support KV metadata

### DIFF
--- a/src/kv.d.ts
+++ b/src/kv.d.ts
@@ -60,7 +60,7 @@ export namespace KV {
 export declare class Database<Models, Identifiers extends Record<keyof Models, string> = { [P in keyof Models]: string}> {
 	constructor(binding: KV.Namespace);
 	get<K extends keyof Models>(type: K, uid: Identifiers[K], format?: KV.GetFormat): Promise<Models[K] | false>;
-	put<K extends keyof Models, M extends KV.Metadata = KV.Metadata>(type: K, uid: Identifiers[K], value: Models[K], toJSON?: boolean, options?: KV.Options.Put<M>): Promise<boolean>;
+	put<K extends keyof Models, M extends KV.Metadata = KV.Metadata>(type: K, uid: Identifiers[K], value: Models[K], options?: Options.Write<M>): Promise<boolean>;
 	del<K extends keyof Models>(type: K, uid: Identifiers[K]): Promise<boolean>;
 }
 
@@ -68,9 +68,12 @@ export function read<T extends ArrayBuffer>(binding: KV.Namespace, key: string, 
 export function read<T extends ReadableStream>(binding: KV.Namespace, key: string, options: 'stream' | KV.Options.Get<'stream'>): Promise<T|false>;
 export function read<T extends string>(binding: KV.Namespace, key: string, options: 'text' | KV.Options.Get<'text'>): Promise<T|false>;
 export function read<T>(binding: KV.Namespace, key: string, options?: 'json' | KV.Options.Get<'json'>): Promise<T|false>;
+// Custom method options
+declare namespace Options {
+	type Write<M extends KV.Metadata = KV.Metadata> = KV.Options.Put<M> & { toJSON?: boolean };
+}
 
-// TODO: move toJSON to options?
-export function write<T, M extends KV.Metadata = KV.Metadata>(binding: KV.Namespace, key: string, value: T, options?: KV.Options.Put<M>): Promise<boolean>;
+export function write<T, M extends KV.Metadata = KV.Metadata>(binding: KV.Namespace, key: string, value: T, options?: Options.Write<M>): Promise<boolean>;
 export function remove(binding: KV.Namespace, key: string): Promise<boolean>;
 
 export function until<X extends string>(

--- a/src/kv.d.ts
+++ b/src/kv.d.ts
@@ -44,7 +44,21 @@ export declare class Database<Models, Identifiers extends Record<keyof Models, s
 	del<K extends keyof Models>(type: K, uid: Identifiers[K]): Promise<boolean>;
 }
 
-export function read<T>(binding: KV.Namespace, key: string, format?: KV.GetOptions): Promise<T | false>;
+export function read<T>(key: string, type: 'json'): Promise<T|false>;
+export function read<T>(key: string, options: KV.GetOptions<'json'>): Promise<T|false>;
+
+export function read<T extends ReadableStream>(key: string, type: 'stream'): Promise<T|false>;
+export function read<T extends ReadableStream>(key: string, options: KV.GetOptions<'stream'>): Promise<T|false>;
+
+export function read(key: string, type: 'arrayBuffer'): Promise<ArrayBuffer|false>;
+export function read(key: string, options: KV.GetOptions<'arrayBuffer'>): Promise<ArrayBuffer|false>;
+
+export function read<T extends string>(key: string, type: 'text'): Promise<T|false>;
+export function read<T extends string>(key: string, options: KV.GetOptions<'text'>): Promise<T|false>;
+
+export function read<T extends string>(binding: KV.Namespace, key: string, format?: KV.GetFormat): Promise<T | false>;
+export function read<T extends string>(binding: KV.Namespace, key: string, options?: KV.GetOptions<KV.GetFormat>): Promise<T | false>;
+
 export function write<T>(binding: KV.Namespace, key: string, value: T, toJSON?: boolean, options?: KV.WriteOptions): Promise<boolean>;
 export function remove(binding: KV.Namespace, key: string): Promise<boolean>;
 

--- a/src/kv.d.ts
+++ b/src/kv.d.ts
@@ -1,10 +1,16 @@
 export namespace KV {
+	type Metadata = Record<string, any>;
 	type Value = string | ReadableStream | ArrayBuffer;
 	type WriteOptions = { expiration?: number; expirationTtl?: number };
 	type ListOptions = { prefix?: string; limit?: number; cursor?: string };
 
 	type GetFormat = 'text' | 'json' | 'arrayBuffer' | 'stream';
 	type GetOptions<T> = { type: T; cacheTtl?: number };
+	type GetMetadata<T, M> = {
+		value: T | null;
+		metadata: M | null;
+	}
+
 
 	interface KeyList {
 		keys: Array<{ name: string; expiration?: number }>;
@@ -28,8 +34,20 @@ export namespace KV {
 		get<T>(key: string, type?: GetFormat): Promise<string|null>; // "text"
 		get<T>(key: string, options?: GetOptions<GetFormat> ): Promise<string|null>; // "text"
 
+		getWithMetadata<T, M extends Metadata>(key: string, type: 'json'): Promise<GetMetadata<T, M>>;
+		getWithMetadata<T, M extends Metadata>(key: string, options: GetOptions<'json'>): Promise<GetMetadata<T, M>>;
 
+		getWithMetadata<T, M extends Metadata>(key: string, type: 'stream'): Promise<GetMetadata<ReadableStream, M>>;
+		getWithMetadata<T, M extends Metadata>(key: string, options: GetOptions<'stream'>): Promise<GetMetadata<ReadableStream, M>>;
 
+		getWithMetadata<T, M extends Metadata>(key: string, type: 'arrayBuffer'): Promise<GetMetadata<ArrayBuffer, M>>;
+		getWithMetadata<T, M extends Metadata>(key: string, options: GetOptions<'arrayBuffer'>): Promise<GetMetadata<ArrayBuffer, M>>;
+
+		getWithMetadata<T, M extends Metadata>(key: string, type: 'text'): Promise<GetMetadata<string, M>>;
+		getWithMetadata<T, M extends Metadata>(key: string, options: GetOptions<'text'>): Promise<GetMetadata<string, M>>;
+
+		getWithMetadata<T, M extends Metadata>(key: string, type?: GetFormat): Promise<GetMetadata<string, M>>; // "text"
+		getWithMetadata<T, M extends Metadata>(key: string, options?: GetOptions<GetFormat>): Promise<GetMetadata<string, M>>; // "text"
 
 		put(key: string, value: Value, options?: WriteOptions): Promise<void>;
 		list(options?: ListOptions): Promise<KeyList>;

--- a/src/kv.d.ts
+++ b/src/kv.d.ts
@@ -59,19 +59,21 @@ export namespace KV {
 
 export declare class Database<Models, Identifiers extends Record<keyof Models, string> = { [P in keyof Models]: string}> {
 	constructor(binding: KV.Namespace);
-	get<K extends keyof Models>(type: K, uid: Identifiers[K], format?: KV.GetFormat): Promise<Models[K] | false>;
+	get<K extends keyof Models>(type: K, uid: Identifiers[K], format?: KV.GetFormat | KV.Options.Get): Promise<Models[K] | null>;
 	put<K extends keyof Models, M extends KV.Metadata = KV.Metadata>(type: K, uid: Identifiers[K], value: Models[K], options?: Options.Write<M>): Promise<boolean>;
 	del<K extends keyof Models>(type: K, uid: Identifiers[K]): Promise<boolean>;
 }
 
-export function read<T extends ArrayBuffer>(binding: KV.Namespace, key: string, options: 'arrayBuffer' | KV.Options.Get<'arrayBuffer'>): Promise<T|false>;
-export function read<T extends ReadableStream>(binding: KV.Namespace, key: string, options: 'stream' | KV.Options.Get<'stream'>): Promise<T|false>;
-export function read<T extends string>(binding: KV.Namespace, key: string, options: 'text' | KV.Options.Get<'text'>): Promise<T|false>;
-export function read<T>(binding: KV.Namespace, key: string, options?: 'json' | KV.Options.Get<'json'>): Promise<T|false>;
 // Custom method options
 declare namespace Options {
 	type Write<M extends KV.Metadata = KV.Metadata> = KV.Options.Put<M> & { toJSON?: boolean };
 }
+
+// Get raw item value
+export function read<T extends ArrayBuffer>(binding: KV.Namespace, key: string, options: 'arrayBuffer' | KV.Options.Get<'arrayBuffer'>): Promise<T|null>;
+export function read<T extends ReadableStream>(binding: KV.Namespace, key: string, options: 'stream' | KV.Options.Get<'stream'>): Promise<T|null>;
+export function read<T extends string>(binding: KV.Namespace, key: string, options: 'text' | KV.Options.Get<'text'>): Promise<T|null>;
+export function read<T>(binding: KV.Namespace, key: string, options?: 'json' | KV.Options.Get<'json'>): Promise<T|null>;
 
 export function write<T, M extends KV.Metadata = KV.Metadata>(binding: KV.Namespace, key: string, value: T, options?: Options.Write<M>): Promise<boolean>;
 export function remove(binding: KV.Namespace, key: string): Promise<boolean>;

--- a/src/kv.d.ts
+++ b/src/kv.d.ts
@@ -4,7 +4,7 @@ export namespace KV {
 
 	type GetFormat = 'text' | 'json' | 'arrayBuffer' | 'stream';
 
-	type GetMetadata<T, M> = {
+	type GetMetadata<T, M extends Metadata = Metadata> = {
 		value: T | null;
 		metadata: M | null;
 	}
@@ -59,21 +59,30 @@ export namespace KV {
 
 export declare class Database<Models, Identifiers extends Record<keyof Models, string> = { [P in keyof Models]: string}> {
 	constructor(binding: KV.Namespace);
-	get<K extends keyof Models>(type: K, uid: Identifiers[K], format?: KV.GetFormat | KV.Options.Get): Promise<Models[K] | null>;
-	put<K extends keyof Models, M extends KV.Metadata = KV.Metadata>(type: K, uid: Identifiers[K], value: Models[K], options?: Options.Write<M>): Promise<boolean>;
+	get<K extends keyof Models>(type: K, uid: Identifiers[K], options: Options.Read & { metadata: true }): Promise<KV.GetMetadata<Models[K]>>;
+	get<K extends keyof Models>(type: K, uid: Identifiers[K], options?: KV.GetFormat | (Options.Read & { metadata?: false })): Promise<Models[K] | null>;
+
+	put<K extends keyof Models>(type: K, uid: Identifiers[K], value: Models[K], options?: Options.Write): Promise<boolean>;
 	del<K extends keyof Models>(type: K, uid: Identifiers[K]): Promise<boolean>;
 }
 
 // Custom method options
 declare namespace Options {
+	type Read<T extends KV.GetFormat = KV.GetFormat> = KV.Options.Get<T> & { metadata?: boolean };
 	type Write<M extends KV.Metadata = KV.Metadata> = KV.Options.Put<M> & { toJSON?: boolean };
 }
 
-// Get raw item value
-export function read<T extends ArrayBuffer>(binding: KV.Namespace, key: string, options: 'arrayBuffer' | KV.Options.Get<'arrayBuffer'>): Promise<T|null>;
-export function read<T extends ReadableStream>(binding: KV.Namespace, key: string, options: 'stream' | KV.Options.Get<'stream'>): Promise<T|null>;
-export function read<T extends string>(binding: KV.Namespace, key: string, options: 'text' | KV.Options.Get<'text'>): Promise<T|null>;
-export function read<T>(binding: KV.Namespace, key: string, options?: 'json' | KV.Options.Get<'json'>): Promise<T|null>;
+// Get item value with metadata
+export function read<T extends ArrayBuffer, M extends KV.Metadata = KV.Metadata>(binding: KV.Namespace, key: string, options: Options.Read<'arrayBuffer'> & { metadata: true }): Promise<KV.GetMetadata<T, M>>;
+export function read<T extends ReadableStream, M extends KV.Metadata = KV.Metadata>(binding: KV.Namespace, key: string, options: Options.Read<'stream'> & { metadata: true }): Promise<KV.GetMetadata<T, M>>;
+export function read<T extends string, M extends KV.Metadata = KV.Metadata>(binding: KV.Namespace, key: string, options: Options.Read<'text'> & { metadata: true }): Promise<KV.GetMetadata<T, M>>;
+export function read<T, M extends KV.Metadata = KV.Metadata>(binding: KV.Namespace, key: string, options: Options.Read<'json'> & { metadata: true }): Promise<KV.GetMetadata<T, M>>;
+
+// Get raw item value (no metadata)
+export function read<T extends ArrayBuffer>(binding: KV.Namespace, key: string, options: 'arrayBuffer' | Options.Read<'arrayBuffer'>): Promise<T|null>;
+export function read<T extends ReadableStream>(binding: KV.Namespace, key: string, options: 'stream' | Options.Read<'stream'>): Promise<T|null>;
+export function read<T extends string>(binding: KV.Namespace, key: string, options: 'text' | Options.Read<'text'>): Promise<T|null>;
+export function read<T>(binding: KV.Namespace, key: string, options?: 'json' | Options.Read<'json'>): Promise<T|null>;
 
 export function write<T, M extends KV.Metadata = KV.Metadata>(binding: KV.Namespace, key: string, value: T, options?: Options.Write<M>): Promise<boolean>;
 export function remove(binding: KV.Namespace, key: string): Promise<boolean>;

--- a/src/kv.d.ts
+++ b/src/kv.d.ts
@@ -13,20 +13,21 @@ export namespace KV {
 	}
 
 	interface Namespace {
-		get<T>(key: string, type: 'json'): Promise<T>;
-		get<T>(key: string, options: GetOptions<'json'>): Promise<T>;
+		get<T>(key: string, type: 'json'): Promise<T|null>;
+		get<T>(key: string, options: GetOptions<'json'>): Promise<T|null>;
 
-		get<T>(key: string, type: 'stream'): Promise<ReadableStream>;
-		get<T>(key: string, options: GetOptions<'stream'>): Promise<ReadableStream>;
+		get<T>(key: string, type: 'stream'): Promise<ReadableStream|null>;
+		get<T>(key: string, options: GetOptions<'stream'>): Promise<ReadableStream|null>;
 
-		get<T>(key: string, type: 'arrayBuffer'): Promise<ArrayBuffer>;
-		get<T>(key: string, options: GetOptions<'arrayBuffer'>): Promise<ArrayBuffer>;
+		get<T>(key: string, type: 'arrayBuffer'): Promise<ArrayBuffer|null>;
+		get<T>(key: string, options: GetOptions<'arrayBuffer'>): Promise<ArrayBuffer|null>;
 
-		get<T>(key: string, type: 'text'): Promise<string>;
-		get<T>(key: string, options: GetOptions<'text'>): Promise<string>;
+		get<T>(key: string, type: 'text'): Promise<string|null>;
+		get<T>(key: string, options: GetOptions<'text'>): Promise<string|null>;
 
-		get<T>(key: string, type?: GetFormat): Promise<string>; // "text"
-		get<T>(key: string, options?: GetOptions<GetFormat> ): Promise<string>; // "text"
+		get<T>(key: string, type?: GetFormat): Promise<string|null>; // "text"
+		get<T>(key: string, options?: GetOptions<GetFormat> ): Promise<string|null>; // "text"
+
 
 
 

--- a/src/kv.d.ts
+++ b/src/kv.d.ts
@@ -2,7 +2,9 @@ export namespace KV {
 	type Value = string | ReadableStream | ArrayBuffer;
 	type WriteOptions = { expiration?: number; expirationTtl?: number };
 	type ListOptions = { prefix?: string; limit?: number; cursor?: string };
-	type GetOptions = 'text' | 'json' | 'arrayBuffer' | 'stream';
+
+	type GetFormat = 'text' | 'json' | 'arrayBuffer' | 'stream';
+	type GetOptions<T> = { type: T; cacheTtl?: number };
 
 	interface KeyList {
 		keys: Array<{ name: string; expiration?: number }>;
@@ -12,11 +14,21 @@ export namespace KV {
 
 	interface Namespace {
 		get<T>(key: string, type: 'json'): Promise<T>;
+		get<T>(key: string, options: GetOptions<'json'>): Promise<T>;
+
 		get<T>(key: string, type: 'stream'): Promise<ReadableStream>;
+		get<T>(key: string, options: GetOptions<'stream'>): Promise<ReadableStream>;
+
 		get<T>(key: string, type: 'arrayBuffer'): Promise<ArrayBuffer>;
+		get<T>(key: string, options: GetOptions<'arrayBuffer'>): Promise<ArrayBuffer>;
+
 		get<T>(key: string, type: 'text'): Promise<string>;
-		get<T>(key: string, type: GetOptions): Promise<T>;
-		get<T>(key: string): Promise<string>; // "text"
+		get<T>(key: string, options: GetOptions<'text'>): Promise<string>;
+
+		get<T>(key: string, type?: GetFormat): Promise<string>; // "text"
+		get<T>(key: string, options?: GetOptions<GetFormat> ): Promise<string>; // "text"
+
+
 
 		put(key: string, value: Value, options?: WriteOptions): Promise<void>;
 		list(options?: ListOptions): Promise<KeyList>;
@@ -26,7 +38,7 @@ export namespace KV {
 
 export declare class Database<Models, Identifiers extends Record<keyof Models, string> = { [P in keyof Models]: string}> {
 	constructor(binding: KV.Namespace);
-	get<K extends keyof Models>(type: K, uid: Identifiers[K], format?: KV.GetOptions): Promise<Models[K] | false>;
+	get<K extends keyof Models>(type: K, uid: Identifiers[K], format?: KV.GetFormat): Promise<Models[K] | false>;
 	put<K extends keyof Models>(type: K, uid: Identifiers[K], value: Models[K], toJSON?: boolean, options?: KV.WriteOptions): Promise<boolean>;
 	del<K extends keyof Models>(type: K, uid: Identifiers[K]): Promise<boolean>;
 }

--- a/src/kv.test.ts
+++ b/src/kv.test.ts
@@ -77,15 +77,15 @@ write('should return `false` instead of throwing', async () => {
 	assert.is(await KV.write(binding, 'foobar', 'value'), false);
 });
 
-write('should force `JSON.stringify` on value :: param=true', async () => {
+write('should force `JSON.stringify` on value :: { toJSON: true }', async () => {
 	let binding = Namespace();
 	binding.put = Mock();
 
 	let input = 'value';
 	let real = JSON.stringify('value');
 
-	await KV.write(binding, 'foobar', input, true);
-	assert.equal(binding.put.args(), ['foobar', real, undefined]);
+	await KV.write(binding, 'foobar', input, { toJSON: true });
+	assert.equal(binding.put.args(), ['foobar', real, { toJSON: true }]);
 });
 
 write('should force `JSON.stringify` on value :: object', async () => {
@@ -130,13 +130,13 @@ write('should skip `JSON.stringify` :: ReadableStream', async () => {
 	assert.equal(binding.put.args(), ['foobar', item, undefined]);
 });
 
-write('should ignore `JSON.stringify` :: ReadableStream', async () => {
+write('should ignore `toJSON` option :: ReadableStream', async () => {
 	let binding = Namespace();
 	binding.put = Mock();
 
 	let item = new ReadableStream();
-	await KV.write(binding, 'foobar', item, true);
-	assert.equal(binding.put.args(), ['foobar', item, undefined]);
+	await KV.write(binding, 'foobar', item, { toJSON: true });
+	assert.equal(binding.put.args(), ['foobar', item, { toJSON: true }]);
 });
 
 write('should skip `JSON.stringify` :: ArrayBuffer', async () => {
@@ -148,13 +148,13 @@ write('should skip `JSON.stringify` :: ArrayBuffer', async () => {
 	assert.equal(binding.put.args(), ['foobar', item, undefined]);
 });
 
-write('should ignore `JSON.stringify` :: ArrayBuffer', async () => {
+write('should ignore `toJSON` option :: ArrayBuffer', async () => {
 	let binding = Namespace();
 	binding.put = Mock();
 
 	let item = new ArrayBuffer(1);
-	await KV.write(binding, 'foobar', item, true);
-	assert.equal(binding.put.args(), ['foobar', item, undefined]);
+	await KV.write(binding, 'foobar', item, { toJSON: true });
+	assert.equal(binding.put.args(), ['foobar', item, { toJSON: true }]);
 });
 
 write('shoud allow `expiration` options', async () => {
@@ -164,7 +164,7 @@ write('shoud allow `expiration` options', async () => {
 	let input = { foo: 123 };
 	let real = JSON.stringify(input);
 	let options = { expiration: 123 };
-	await KV.write(binding, 'foobar', input, true, options);
+	await KV.write(binding, 'foobar', input, options);
 	assert.equal(binding.put.args(), ['foobar', real, options]);
 });
 
@@ -268,12 +268,12 @@ Database('should proxy `binding.put` via `DB.put` method', async () => {
 
 	binding.put = Mock();
 	assert.is(await DB.put('user', 'foobar', user), true); // success
-	assert.equal(binding.put.args(), ['user__foobar', real, undefined]);
+	assert.equal(binding.put.args(), ['user__foobar', real, { toJSON: true }]);
 
 	binding.put = Mock();
 	let options = { expiration: 12345 };
-	assert.is(await DB.put('user', 'foobar', user, true, options), true); // success
-	assert.equal(binding.put.args(), ['user__foobar', real, options]);
+	assert.is(await DB.put('user', 'foobar', user, options), true); // success
+	assert.equal(binding.put.args(), ['user__foobar', real, { toJSON: true, ...options }]);
 });
 
 Database('should proxy `binding.delete` via `DB.del` method', async () => {
@@ -315,10 +315,10 @@ Database('should allow `DB.put()` to save non-JSON', async () => {
 	let real = JSON.stringify(input);
 
 	await DB.put('foo', 'id', input);
-	assert.equal(binding.put.args(), ['foo__id', real, undefined]);
+	assert.equal(binding.put.args(), ['foo__id', real, { toJSON: true }]);
 
-	await DB.put('foo', 'id', input, false); // NO CAST
-	assert.equal(binding.put.args(), ['foo__id', input, undefined]);
+	await DB.put('foo', 'id', input, { toJSON: false }); // NO CAST
+	assert.equal(binding.put.args(), ['foo__id', input, { toJSON: false }]);
 });
 
 Database.run();

--- a/src/kv.test.ts
+++ b/src/kv.test.ts
@@ -33,12 +33,12 @@ read('should return false if `get()` returns null', async () => {
 	let binding = Namespace();
 	binding.get = Mock(null);
 
-	assert.is(await KV.read(binding, 'foobar'), false);
+	assert.is(await KV.read(binding, 'foobar'), null);
 });
 
-read('should return false if `get()` returns undefined', async () => {
+read('should return false if `get()` returns false', async () => {
 	let binding = Namespace();
-	binding.get = Mock(undefined);
+	binding.get = Mock(false);
 
 	assert.is(await KV.read(binding, 'foobar'), false);
 });
@@ -242,8 +242,8 @@ Database('should proxy `binding.get` via `DB.get` method', async () => {
 	const DB = KV.Database<Models>(binding);
 	let user: Partial<IUser> = { id: 'foobar' };
 
-	binding.get = Mock(); // undefined => false
-	assert.is(await DB.get('user', 'foobar'), false);
+	binding.get = Mock(null); // null => as is
+	assert.is(await DB.get('user', 'foobar'), null);
 	assert.equal(binding.get.args(), ['user__foobar', 'json']);
 
 	binding.get = Mock(user);

--- a/src/kv.ts
+++ b/src/kv.ts
@@ -1,27 +1,28 @@
 import type { KV, Database as DB } from 'worktop/kv';
 
-export function Database<M, I extends Record<keyof M, string> = { [P in keyof M]: string }>(binding: KV.Namespace): DB<M, I> {
+export function Database<Models, I extends Record<keyof Models, string> = { [P in keyof Models]: string }>(binding: KV.Namespace): DB<Models, I> {
 	var $ = <K extends keyof I>(type: K, uid: I[K]) => `${type}__${uid}`;
 
 	return {
-		get<K extends keyof M>(type: K, uid: I[K], format?: KV.GetOptions) {
-			return read<M[K]>(binding, $(type, uid), format);
+		get<K extends keyof Models>(type: K, uid: I[K], format?: KV.Options.Get | KV.GetFormat) {
+			return read<Models[K]>(binding, $(type, uid), format);
 		},
-		put<K extends keyof M>(type: K, uid: I[K], value: M[K], toJSON = true, options?: KV.WriteOptions) {
-			return write<M[K]>(binding, $(type, uid), value, toJSON, options);
+		put<K extends keyof Models, M extends KV.Metadata = KV.Metadata>(type: K, uid: I[K], value: Models[K], toJSON = true, options?: KV.Options.Put<M>) {
+			return write<Models[K]>(binding, $(type, uid), value, toJSON, options);
 		},
-		del<K extends keyof M>(type: K, uid: I[K]) {
+		del<K extends keyof Models>(type: K, uid: I[K]) {
 			return remove(binding, $(type, uid));
 		}
 	};
 }
 
-export function read<T>(binding: KV.Namespace, key: string, format: KV.GetOptions = 'json'): Promise<T | false> {
+export function read<T>(binding: KV.Namespace, key: string, format: KV.Options.Get | KV.GetFormat = 'json'): Promise<T|false> {
+	// @ts-ignore - T + generic `format` pattern match
 	return binding.get<T>(key, format).then(x => x != null ? x : false);
 }
 
-export function write<T=any>(binding: KV.Namespace, key: string, value: T, toJSON?: boolean, options?: KV.WriteOptions): Promise<boolean> {
-	return binding.put(key, (!toJSON && typeof value === 'string') || value instanceof ArrayBuffer || value instanceof ReadableStream ? value : JSON.stringify(value), options).then(() => true, () => false);
+export function write<T, M extends KV.Metadata = KV.Metadata>(binding: KV.Namespace, key: string, value: T, toJSON?: boolean, options?: KV.Options.Put<M>): Promise<boolean> {
+	return binding.put<M>(key, (!toJSON && typeof value === 'string') || value instanceof ArrayBuffer || value instanceof ReadableStream ? value : JSON.stringify(value), options).then(() => true, () => false);
 }
 
 export function remove(binding: KV.Namespace, key: string): Promise<boolean> {

--- a/src/kv.ts
+++ b/src/kv.ts
@@ -4,7 +4,8 @@ export function Database<Models, I extends Record<keyof Models, string> = { [P i
 	var $ = <K extends keyof I>(type: K, uid: I[K]) => `${type}__${uid}`;
 
 	return {
-		get<K extends keyof Models>(type: K, uid: I[K], format?: KV.Options.Get | KV.GetFormat) {
+		// @ts-ignore - dont want to redefine overloads in source
+		get<K extends keyof Models>(type: K, uid: I[K], format?: Options.Read | KV.GetFormat) {
 			return read<Models[K]>(binding, $(type, uid), format);
 		},
 		put<K extends keyof Models, M extends KV.Metadata = KV.Metadata>(type: K, uid: I[K], value: Models[K], options?: Options.Write<M>) {
@@ -16,9 +17,9 @@ export function Database<Models, I extends Record<keyof Models, string> = { [P i
 	};
 }
 
-export function read<T>(binding: KV.Namespace, key: string, format: KV.Options.Get | KV.GetFormat = 'json'): Promise<T|null> {
-	// @ts-ignore - thinks can be "json" only because of unknown `T` pattern match
-	return binding.get<T>(key, format);
+export function read<T, M extends KV.Metadata = KV.Metadata>(binding: KV.Namespace, key: string, format: Options.Read | KV.GetFormat = 'json'): Promise<T|null> {
+	// @ts-ignore - the compiler thinks "json" is only available `format` option because of unknown `T` pattern match
+	return (typeof format === 'string' || !format.metadata) ? binding.get<T>(key, format) : binding.getWithMetadata<T, M>(key, format);
 }
 
 export function write<T, M extends KV.Metadata = KV.Metadata>(binding: KV.Namespace, key: string, val: T, options?: Options.Write<M>): Promise<boolean> {

--- a/src/kv.ts
+++ b/src/kv.ts
@@ -16,9 +16,9 @@ export function Database<Models, I extends Record<keyof Models, string> = { [P i
 	};
 }
 
-export function read<T>(binding: KV.Namespace, key: string, format: KV.Options.Get | KV.GetFormat = 'json'): Promise<T|false> {
-	// @ts-ignore - T + generic `format` pattern match
-	return binding.get<T>(key, format).then(x => x != null ? x : false);
+export function read<T>(binding: KV.Namespace, key: string, format: KV.Options.Get | KV.GetFormat = 'json'): Promise<T|null> {
+	// @ts-ignore - thinks can be "json" only because of unknown `T` pattern match
+	return binding.get<T>(key, format);
 }
 
 export function write<T, M extends KV.Metadata = KV.Metadata>(binding: KV.Namespace, key: string, val: T, options?: Options.Write<M>): Promise<boolean> {

--- a/types/check.ts
+++ b/types/check.ts
@@ -480,8 +480,8 @@ async function storage() {
 	await DB2.get('app', len11);
 	await DB1.get('app', 'asd'); // DB1 is guessing
 
-	assert<IUser|false>(await DB1.get('user', 'id'));
-	assert<IApp|false>(await DB2.get('app', len11));
+	assert<IUser|null>(await DB1.get('user', 'id'));
+	assert<IApp|null>(await DB2.get('app', len11));
 
 	let user: IUser = {
 		id: 'asd',

--- a/types/check.ts
+++ b/types/check.ts
@@ -489,9 +489,16 @@ async function storage() {
 		age: 123
 	};
 
-	assert<boolean>(await DB1.put('user', user.id, user, true));
+	assert<boolean>(await DB1.put('user', user.id, user, { toJSON: false }));
+	assert<boolean>(await DB1.put('user', user.id, user, { toJSON: true }));
 	assert<boolean>(await DB1.put('user', user.id, user));
 	assert<boolean>(await DB1.del('user', user.id));
+
+	await DB1.put('user', user.id, user, {
+		toJSON: false,
+		expiration: 123,
+		metadata: { foo: 123 }
+	});
 
 	const lookup = (uid: Fixed.String<11>) => DB2.get('app', uid);
 	assert<Fixed.String<11>>(await until(toUID, lookup));


### PR DESCRIPTION
**Breaking**

- the `write` signature changed, merging the `toJSON?: boolean` and `options = {}` parameters together
- the `Database.put` signature changed, following the changes to `write`

- the `read` method does not return `Promise<T|false>` anymore. Instead, the native `Promise<T|null>` is forwarded.
- the `Database.get` signature changed, following the changes to `read`

**Features**

- Both  `Database.put` and `write` support [adding key metadata](https://developers.cloudflare.com/workers/runtime-apis/kv#metadata) via `options.metadata` 
- Both `Database.get` and `read` support _retrieval_ of keys with their metadata. This is done via `options.metadata = true` and, when enabled, returns an object of `{ value, metadata }` instead of _just_ the value.

**Patches**

- Fixed & Added a bunch of native `KV.Namespace` types

---

Related: #42 