### PR TITLE
feat(kv): add `list` and `paginate` methods

### DIFF
--- a/src/kv.d.ts
+++ b/src/kv.d.ts
@@ -68,9 +68,15 @@ export declare class Database<Models, Identifiers extends Record<keyof Models, s
 
 // Custom method options
 declare namespace Options {
-	type List = KV.Options.List & { metadata?: boolean };
 	type Read<T extends KV.GetFormat = KV.GetFormat> = KV.Options.Get<T> & { metadata?: boolean };
 	type Write<M extends KV.Metadata = KV.Metadata> = KV.Options.Put<M> & { toJSON?: boolean };
+	type List = KV.Options.List & { metadata?: boolean };
+	type Paginate = {
+		page?: number;
+		limit?: number;
+		prefix?: string;
+		metadata?: boolean;
+	}
 }
 
 // Get item value with metadata
@@ -88,8 +94,11 @@ export function read<T>(binding: KV.Namespace, key: string, options?: 'json' | O
 export function write<T, M extends KV.Metadata = KV.Metadata>(binding: KV.Namespace, key: string, value: T, options?: Options.Write<M>): Promise<boolean>;
 export function remove(binding: KV.Namespace, key: string): Promise<boolean>;
 
-export function list<M extends KV.Metadata = KV.Metadata>(binding: KV.Namespace, options: Options.List & { metadata: true }): AsyncGenerator<{ done: boolean; keys: KV.KeyInfo<M>[] }>;
-export function list(binding: KV.Namespace, options?: Options.List & { metadata?: false }): AsyncGenerator<{ done: boolean; keys: string[] }>;
+export function list<M extends KV.Metadata>(binding: KV.Namespace, options: Options.List & { metadata: true }): AsyncGenerator<{ done: boolean; keys: KV.KeyInfo<M>[] }>;
+export function list(binding: KV.Namespace, options?: Options.List): AsyncGenerator<{ done: boolean; keys: string[] }>;
+
+export function paginate<M extends KV.Metadata>(binding: KV.Namespace, options: Options.Paginate & { metadata: true }): Promise<KV.KeyInfo<M>[]>;
+export function paginate(binding: KV.Namespace, options?: Options.Paginate & { metadata?: false }): Promise<string[]>;
 
 export function until<X extends string>(
 	toMake: () => X,

--- a/src/kv.d.ts
+++ b/src/kv.d.ts
@@ -21,7 +21,7 @@ export namespace KV {
 		cursor?: string;
 	}
 
-	declare namespace Options {
+	namespace Options {
 		type List = {
 			prefix?: string;
 			cursor?: string;
@@ -67,7 +67,7 @@ export declare class Database<Models, Identifiers extends Record<keyof Models, s
 }
 
 // Custom method options
-declare namespace Options {
+export namespace Options {
 	type Read<T extends KV.GetFormat = KV.GetFormat> = KV.Options.Get<T> & { metadata?: boolean };
 	type Write<M extends KV.Metadata = KV.Metadata> = KV.Options.Put<M> & { toJSON?: boolean };
 	type List = KV.Options.List & { metadata?: boolean };
@@ -94,11 +94,11 @@ export function read<T>(binding: KV.Namespace, key: string, options?: 'json' | O
 export function write<T, M extends KV.Metadata = KV.Metadata>(binding: KV.Namespace, key: string, value: T, options?: Options.Write<M>): Promise<boolean>;
 export function remove(binding: KV.Namespace, key: string): Promise<boolean>;
 
-export function list<M extends KV.Metadata>(binding: KV.Namespace, options: Options.List & { metadata: true }): AsyncGenerator<{ done: boolean; keys: KV.KeyInfo<M>[] }>;
-export function list(binding: KV.Namespace, options?: Options.List): AsyncGenerator<{ done: boolean; keys: string[] }>;
+export function list<M extends KV.Metadata>(binding: KV.Namespace, options?: Options.List & { metadata: true }): AsyncGenerator<{ done: boolean; keys: KV.KeyInfo<M>[] }>;
+export function list<M extends KV.Metadata>(binding: KV.Namespace, options?: Options.List): AsyncGenerator<{ done: boolean; keys: string[] }>;
 
-export function paginate<M extends KV.Metadata>(binding: KV.Namespace, options: Options.Paginate & { metadata: true }): Promise<KV.KeyInfo<M>[]>;
-export function paginate(binding: KV.Namespace, options?: Options.Paginate & { metadata?: false }): Promise<string[]>;
+export function paginate<M extends KV.Metadata>(binding: KV.Namespace, options?: Options.Paginate & { metadata: true }): Promise<KV.KeyInfo<M>[]>;
+export function paginate<M extends KV.Metadata>(binding: KV.Namespace, options?: Options.Paginate & { metadata?: false }): Promise<string[]>;
 
 export function until<X extends string>(
 	toMake: () => X,

--- a/src/kv.d.ts
+++ b/src/kv.d.ts
@@ -9,13 +9,13 @@ export namespace KV {
 		metadata: M | null;
 	}
 
-	interface KeyInfo<M extends Metadata> {
+	interface KeyInfo<M extends Metadata = Metadata> {
 		name: string;
 		expiration?: number;
 		metadata?: M;
 	}
 
-	interface KeyList<M extends Metadata> {
+	interface KeyList<M extends Metadata = Metadata> {
 		keys: KeyInfo<M>[];
 		list_complete: boolean;
 		cursor?: string;
@@ -68,6 +68,7 @@ export declare class Database<Models, Identifiers extends Record<keyof Models, s
 
 // Custom method options
 declare namespace Options {
+	type List = KV.Options.List & { metadata?: boolean };
 	type Read<T extends KV.GetFormat = KV.GetFormat> = KV.Options.Get<T> & { metadata?: boolean };
 	type Write<M extends KV.Metadata = KV.Metadata> = KV.Options.Put<M> & { toJSON?: boolean };
 }
@@ -86,6 +87,9 @@ export function read<T>(binding: KV.Namespace, key: string, options?: 'json' | O
 
 export function write<T, M extends KV.Metadata = KV.Metadata>(binding: KV.Namespace, key: string, value: T, options?: Options.Write<M>): Promise<boolean>;
 export function remove(binding: KV.Namespace, key: string): Promise<boolean>;
+
+export function list<M extends KV.Metadata = KV.Metadata>(binding: KV.Namespace, options: Options.List & { metadata: true }): AsyncGenerator<{ done: boolean; keys: KV.KeyInfo<M>[] }>;
+export function list(binding: KV.Namespace, options?: Options.List & { metadata?: false }): AsyncGenerator<{ done: boolean; keys: string[] }>;
 
 export function until<X extends string>(
 	toMake: () => X,

--- a/types/check.ts
+++ b/types/check.ts
@@ -2,7 +2,7 @@ import * as CORS from 'worktop/cors';
 import * as Cache from 'worktop/cache';
 import * as Base64 from 'worktop/base64';
 import { ServerResponse } from 'worktop/response';
-import { Database, list, until } from 'worktop/kv';
+import { Database, list, paginate, until } from 'worktop/kv';
 import { byteLength, HEX, uid, uuid, ulid, randomize } from 'worktop/utils';
 import { listen, reply, Router, compose, STATUS_CODES } from 'worktop';
 import { timingSafeEqual } from 'worktop/crypto';
@@ -568,6 +568,13 @@ async function storage() {
 		assert<KV.Metadata|undefined>(result.keys[0].metadata);
 		assert<IUser|undefined>(result.keys[0].metadata);
 	}
+
+	assert<string[]>(await paginate(APPS, { prefix: 'apps::123' }));
+	assert<string[]>(await paginate(APPS, { prefix: 'apps::123', metadata: false }));
+	assert<KV.KeyInfo[]>(await paginate(APPS, { prefix: 'apps::123', metadata: true }));
+
+	let keys = await paginate(APPS, { page: 2, limit: 12, prefix: 'hello' });
+	assert<string>(keys[0]);
 }
 
 /**


### PR DESCRIPTION
* `list` is an `AsyncGenerator` you can use to manually apply your own stop-until-X logic
* `paginate` applies the 90% use case for consuming the `list()` iterator

For example:

```ts
let keys = await database.paginate(BINDING, { 
  prefix: 'users::1234::projects',
  limit: 25,
  page: 3
});
```

^ this will skip the first 50 keys (2 x 25) and then return the 0-25 keys that constitute a "page 3".
If you supply a `limit` x `page` combination that exceeds the total keys, then an empty array is returned early.

---

Related #42 