### PR TITLE
break(router): remove `find` public method

### DIFF
--- a/src/router.d.ts
+++ b/src/router.d.ts
@@ -45,7 +45,6 @@ export function reply(handler: ResponseHandler): FetchHandler;
  */
 export function listen(handler: ResponseHandler): void;
 
-export type Route = { params: Params; handler: Handler };
 export type Handler<P extends Params = Params> = (req: ServerRequest<P>, res: ServerResponse) => Promisable<Response|void>;
 
 export type RouteParams<T extends string> =
@@ -66,7 +65,6 @@ export type RouteParams<T extends string> =
 export declare class Router {
 	add<T extends RegExp>(method: Method, route: T, handler: Handler<Params>): void;
 	add<T extends string>(method: Method, route: T, handler: Handler<RouteParams<T>>): void;
-	find(method: Method, pathname: string): Route|void;
 	run(event: FetchEvent): Promise<Response>;
 	onerror(req: ServerRequest, res: ServerResponse, status?: number, error?: Error): Promisable<Response>;
 	prepare?(req: Omit<ServerRequest, 'params'>, res: ServerResponse): Promisable<Response|void>;

--- a/types/check.ts
+++ b/types/check.ts
@@ -10,7 +10,7 @@ import * as ws from 'worktop/ws';
 
 import type { KV } from 'worktop/kv';
 import type { UID, UUID, ULID } from 'worktop/utils';
-import type { CronEvent, FetchHandler, Route, RouteParams } from 'worktop';
+import type { CronEvent, FetchHandler, RouteParams } from 'worktop';
 import type { Params, ServerRequest, IncomingCloudflareProperties } from 'worktop/request';
 
 declare function assert<T>(value: T): void;
@@ -167,17 +167,6 @@ API.add('POST', '/items', async (req, res) => {
 	assert<string>(req.cf.tlsClientAuth!.certFingerprintSHA1);
 });
 
-// @ts-expect-error
-API.find(123, 'asd');
-// @ts-expect-error
-API.find('GET', 123);
-// @ts-expect-error
-API.find('GET', /^foo[/]?/);
-
-assert<Route|void>(
-	API.find('GET', '/pathname')
-);
-
 reply(API.run);
 
 reply(event => {
@@ -200,7 +189,7 @@ reply(API.onerror);
 reply(API.run);
 
 // @ts-expect-error
-addEventListener('fetch', API.find);
+addEventListener('fetch', API.add);
 addEventListener('fetch', reply(API.run));
 addEventListener('fetch', Cache.reply(API.run));
 


### PR DESCRIPTION
There's no reason for this to exist on the public API contract. 

In fact, it needs _not to exist_ for upcoming changes.