### PR TITLE
fix types for `connect`

### DIFF
--- a/src/ws.d.ts
+++ b/src/ws.d.ts
@@ -44,7 +44,7 @@ export type SocketHandler<
  * Ensure the incoming `Request` can be upgraded to a Websocket connection.
  * @NOTE This is called automatically within the `listen()` method.
  */
-export const connect: Handler;
+ export function connect(req: ServerRequest<P>): Response|void;
 
 /**
  * Establish a Websocket connection.


### PR DESCRIPTION
Tested against the following code:
```typescript
export const handler: Handler = async (request) => {
  const error = connect(request);
  if (error) return error;
};
```