### PR TITLE
feat(crypto): add `MD5` and `HMAC` exports

### DIFF
--- a/src/crypto.d.ts
+++ b/src/crypto.d.ts
@@ -2,8 +2,6 @@ type SHA = 'SHA-1' | 'SHA-256' | 'SHA-384' | 'SHA-512';
 type AES = 'AES-CTR' | 'AES-CBC' | 'AES-GCM' | 'AES-KW';
 type NIST = 'P-256' | 'P-384' | 'P-521';
 
-export function digest(algorithm: SHA, message: string): Promise<string>;
-
 /**
  * Generate a MD5 hash for an input message.
  * @NOTE Only supported by Cloudflare Workers!
@@ -16,23 +14,28 @@ export function SHA384(message: string): Promise<string>;
 export function SHA512(message: string): Promise<string>;
 
 export namespace Algorithms {
-	type Digest = SHA;
+	/**
+	 * @NOTE Only Cloudflare Workers supports "MD5" as a WebCrypto digest.
+	 */
+	type Digest = SHA | 'MD5';
 
 	type Keying =
-		| { name: 'RSASSA-PKCS1-v1_5'; hash: SHA }
-		| { name: 'RSA-OAEP'; hash: SHA }
-		| { name: 'RSA-PSS'; hash: SHA }
+		| { name: 'RSASSA-PKCS1-v1_5'; hash: Digest }
+		| { name: 'RSA-OAEP'; hash: Digest }
+		| { name: 'RSA-PSS'; hash: Digest }
 		| { name: 'ECDSA'; namedCurve: NIST }
 		| { name: 'ECDH'; namedCurve: NIST }
-		| { name: 'HMAC'; hash: SHA; length?: number }
+		| { name: 'HMAC'; hash: Digest; length?: number }
 		| { name: AES } | AES | 'PBKDF2' | 'HKDF';
 
 	type Signing =
 		| { name: 'RSASSA-PKCS1-v1_5' } | 'RSASSA-PKCS1-v1_5'
 		| { name: 'RSA-PSS'; saltLength: number }
-		| { name: 'ECDSA'; hash: SHA }
+		| { name: 'ECDSA'; hash: Digest }
 		| { name: 'HMAC' } | 'HMAC';
 }
+
+export function digest(algorithm: Algorithms.Digest, message: string): Promise<string>;
 
 /**
  * Generate a `CryptoKey` based on the raw `secret` value.

--- a/src/crypto.d.ts
+++ b/src/crypto.d.ts
@@ -4,6 +4,12 @@ type NIST = 'P-256' | 'P-384' | 'P-521';
 
 export function digest(algorithm: SHA, message: string): Promise<string>;
 
+/**
+ * Generate a MD5 hash for an input message.
+ * @NOTE Only supported by Cloudflare Workers!
+ */
+export function MD5(message: string): Promise<string>;
+
 export function SHA1(message: string): Promise<string>;
 export function SHA256(message: string): Promise<string>;
 export function SHA384(message: string): Promise<string>;

--- a/src/crypto.d.ts
+++ b/src/crypto.d.ts
@@ -88,3 +88,7 @@ export function PBKDF2(digest: Algorithms.Digest, password: string, salt: string
  * HMAC is used to ensure both integrity and authentication.
  */
 export function HMAC(hash: Algorithms.Digest, secret: string, data: string): Promise<ArrayBuffer>;
+
+export function HMAC256(secret: string, message: string): Promise<ArrayBuffer>;
+export function HMAC384(secret: string, message: string): Promise<ArrayBuffer>;
+export function HMAC512(secret: string, message: string): Promise<ArrayBuffer>;

--- a/src/crypto.d.ts
+++ b/src/crypto.d.ts
@@ -79,3 +79,9 @@ export function timingSafeEqual<T extends TypedArray>(a: T, b: T): boolean;
  * @param {number} length   The desired number of bits to derive.
  */
 export function PBKDF2(digest: Algorithms.Digest, password: string, salt: string, iters: number, length: number): Promise<ArrayBuffer>;
+
+/**
+ * Hash-based message authentication code (HMAC).
+ * HMAC is used to ensure both integrity and authentication.
+ */
+export function HMAC(hash: Algorithms.Digest, secret: string, data: string): Promise<ArrayBuffer>;

--- a/src/crypto.test.ts
+++ b/src/crypto.test.ts
@@ -265,3 +265,50 @@ PBKDF2('should produce expected output', async ctx => {
 });
 
 PBKDF2.run();
+
+// ---
+
+const HMAC = suite('HMAC');
+
+HMAC('should be a function', () => {
+	assert.type(crypto.HMAC, 'function');
+});
+
+HMAC('should return ArrayBuffer', async () => {
+	let output = await crypto.HMAC('SHA-1', 'foo', 'bar');
+	assert.instance(output, ArrayBuffer);
+});
+
+HMAC('should produce expected output :: SHA-1', async () => {
+	let foo = await crypto.HMAC('SHA-1', 'hello', 'world').then(toHEX);
+	assert.is(foo, '8a3a84bcd0d0065e97f175d370447c7d02e00973');
+
+	let bar = await crypto.HMAC('SHA-1', 'world', 'hello').then(toHEX);
+	assert.is(bar, '5a0c67d922de0ca53e306250e6858c1f6d2c4943');
+});
+
+HMAC('should produce expected output :: SHA-256', async () => {
+	let foo = await crypto.HMAC('SHA-256', 'hello', 'world').then(toHEX);
+	assert.is(foo, 'f1ac9702eb5faf23ca291a4dc46deddeee2a78ccdaf0a412bed7714cfffb1cc4');
+
+	let bar = await crypto.HMAC('SHA-256', 'world', 'hello').then(toHEX);
+	assert.is(bar, '3cfa76ef14937c1c0ea519f8fc057a80fcd04a7420f8e8bcd0a7567c272e007b');
+});
+
+HMAC('should produce expected output :: SHA-384', async () => {
+	let foo = await crypto.HMAC('SHA-384', 'hello', 'world').then(toHEX);
+	assert.is(foo, '80d036d9974e6f71ceabe493ee897d00235edcc4c72e046ddfc8bf68e86a477d63b9f7d26ad5b990aae6ac17db57ddcf');
+
+	let bar = await crypto.HMAC('SHA-384', 'world', 'hello').then(toHEX);
+	assert.is(bar, '2dc82db49e763d4f589d6b79c788a66ca27a708e8fba0014c36519f4c48e9cb5651d8c86ea6ca0c760219ac3bc009cf8');
+});
+
+HMAC('should produce expected output :: SHA-512', async () => {
+	let foo = await crypto.HMAC('SHA-512', 'hello', 'world').then(toHEX);
+	assert.is(foo, '6668ed2f7d016c5f12d7808fc4f2d1dc4851622d7f15616de947a823b3ee67d761b953f09560da301f832902020dd1c64f496df37eb7ac4fd2feeeb67d77ba9b');
+
+	let bar = await crypto.HMAC('SHA-512', 'world', 'hello').then(toHEX);
+	assert.is(bar, '2b83319d3e78544e4430c4f5621968fee8b6ffa1254678b2c6fb98f7f79ff16afee2da909a7bb741488ca3bacbbf6cec8fd226c5a52eef805ea65a352e2ece8e');
+});
+
+HMAC.run();

--- a/src/crypto.test.ts
+++ b/src/crypto.test.ts
@@ -272,6 +272,9 @@ const HMAC = suite('HMAC');
 
 HMAC('should be a function', () => {
 	assert.type(crypto.HMAC, 'function');
+	assert.type(crypto.HMAC256, 'function');
+	assert.type(crypto.HMAC384, 'function');
+	assert.type(crypto.HMAC512, 'function');
 });
 
 HMAC('should return ArrayBuffer', async () => {
@@ -290,25 +293,31 @@ HMAC('should produce expected output :: SHA-1', async () => {
 HMAC('should produce expected output :: SHA-256', async () => {
 	let foo = await crypto.HMAC('SHA-256', 'hello', 'world').then(toHEX);
 	assert.is(foo, 'f1ac9702eb5faf23ca291a4dc46deddeee2a78ccdaf0a412bed7714cfffb1cc4');
+	assert.is(foo, await crypto.HMAC256('hello', 'world').then(toHEX));
 
 	let bar = await crypto.HMAC('SHA-256', 'world', 'hello').then(toHEX);
 	assert.is(bar, '3cfa76ef14937c1c0ea519f8fc057a80fcd04a7420f8e8bcd0a7567c272e007b');
+	assert.is(bar, await crypto.HMAC256('world', 'hello').then(toHEX));
 });
 
 HMAC('should produce expected output :: SHA-384', async () => {
 	let foo = await crypto.HMAC('SHA-384', 'hello', 'world').then(toHEX);
 	assert.is(foo, '80d036d9974e6f71ceabe493ee897d00235edcc4c72e046ddfc8bf68e86a477d63b9f7d26ad5b990aae6ac17db57ddcf');
+	assert.is(foo, await crypto.HMAC384('hello', 'world').then(toHEX));
 
 	let bar = await crypto.HMAC('SHA-384', 'world', 'hello').then(toHEX);
 	assert.is(bar, '2dc82db49e763d4f589d6b79c788a66ca27a708e8fba0014c36519f4c48e9cb5651d8c86ea6ca0c760219ac3bc009cf8');
+	assert.is(bar, await crypto.HMAC384('world', 'hello').then(toHEX));
 });
 
 HMAC('should produce expected output :: SHA-512', async () => {
 	let foo = await crypto.HMAC('SHA-512', 'hello', 'world').then(toHEX);
 	assert.is(foo, '6668ed2f7d016c5f12d7808fc4f2d1dc4851622d7f15616de947a823b3ee67d761b953f09560da301f832902020dd1c64f496df37eb7ac4fd2feeeb67d77ba9b');
+	assert.is(foo, await crypto.HMAC512('hello', 'world').then(toHEX));
 
 	let bar = await crypto.HMAC('SHA-512', 'world', 'hello').then(toHEX);
 	assert.is(bar, '2b83319d3e78544e4430c4f5621968fee8b6ffa1254678b2c6fb98f7f79ff16afee2da909a7bb741488ca3bacbbf6cec8fd226c5a52eef805ea65a352e2ece8e');
+	assert.is(bar, await crypto.HMAC512('world', 'hello').then(toHEX));
 });
 
 HMAC.run();

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -1,7 +1,7 @@
 import { encode, toHEX } from 'worktop/utils';
 import type { Algorithms, TypedArray } from 'worktop/crypto';
 
-export function digest(algo: Algorithms.Digest | 'MD5', message: string): Promise<string> {
+export function digest(algo: Algorithms.Digest, message: string): Promise<string> {
 	return crypto.subtle.digest(algo, encode(message)).then(toHEX);
 }
 

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -49,3 +49,7 @@ export async function PBKDF2(digest: Algorithms.Digest, password: string, salt: 
 
 	return crypto.subtle.deriveBits(algo, key, length << 3);
 }
+
+export async function HMAC(hash: Algorithms.Digest, secret: string, data: string): Promise<ArrayBuffer> {
+	return keyload({ name: 'HMAC', hash }, secret, ['sign']).then(key => sign('HMAC', key, data));
+}

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -50,6 +50,10 @@ export async function PBKDF2(digest: Algorithms.Digest, password: string, salt: 
 	return crypto.subtle.deriveBits(algo, key, length << 3);
 }
 
-export async function HMAC(hash: Algorithms.Digest, secret: string, data: string): Promise<ArrayBuffer> {
+export function HMAC(hash: Algorithms.Digest, secret: string, data: string): Promise<ArrayBuffer> {
 	return keyload({ name: 'HMAC', hash }, secret, ['sign']).then(key => sign('HMAC', key, data));
 }
+
+export const HMAC256 = /*#__PURE__*/ HMAC.bind(0, 'SHA-256');
+export const HMAC384 = /*#__PURE__*/ HMAC.bind(0, 'SHA-384');
+export const HMAC512 = /*#__PURE__*/ HMAC.bind(0, 'SHA-512');

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -1,10 +1,11 @@
 import { encode, toHEX } from 'worktop/utils';
 import type { Algorithms, TypedArray } from 'worktop/crypto';
 
-export function digest(algo: Algorithms.Digest, message: string): Promise<string> {
+export function digest(algo: Algorithms.Digest | 'MD5', message: string): Promise<string> {
 	return crypto.subtle.digest(algo, encode(message)).then(toHEX);
 }
 
+export const MD5    = /*#__PURE__*/ digest.bind(0, 'MD5');
 export const SHA1   = /*#__PURE__*/ digest.bind(0, 'SHA-1');
 export const SHA256 = /*#__PURE__*/ digest.bind(0, 'SHA-256');
 export const SHA384 = /*#__PURE__*/ digest.bind(0, 'SHA-384');

--- a/types/crypto.ts
+++ b/types/crypto.ts
@@ -70,6 +70,25 @@ assert<string>(
 );
 
 /**
+ * HMAC256
+ */
+
+// @ts-expect-error
+crypto.HMAC256('SHA-256', 'secret', 'data');
+
+assert<Promise<ArrayBuffer>>(
+	crypto.HMAC256('secret', 'data')
+);
+
+assert<ArrayBuffer>(
+	await crypto.HMAC256('secret', 'data')
+);
+
+assert<string>(
+	await crypto.HMAC256('secret', 'data').then(toHEX)
+);
+
+/**
  * PBKDF2
  */
 

--- a/types/crypto.ts
+++ b/types/crypto.ts
@@ -40,6 +40,10 @@ assert<string>(
 	await crypto.digest('SHA-1', 'foobar')
 );
 
+assert<string>(
+	await crypto.digest('MD5', 'foobar')
+);
+
 /**
  * HMAC
  */
@@ -47,6 +51,7 @@ assert<string>(
 // @ts-expect-error
 crypto.HMAC('foobar', 'secret', 'data');
 
+crypto.HMAC('MD5', 'secret', 'data');
 crypto.HMAC('SHA-1', 'secret', 'data');
 crypto.HMAC('SHA-256', 'secret', 'data');
 crypto.HMAC('SHA-384', 'secret', 'data');
@@ -71,6 +76,7 @@ assert<string>(
 // @ts-expect-error
 crypto.PBKDF2('foobar', 'secret', 'salt', 1e3, 32);
 
+crypto.PBKDF2('MD5', 'secret', 'salt', 1e3, 32);
 crypto.PBKDF2('SHA-1', 'secret', 'salt', 1e3, 32);
 crypto.PBKDF2('SHA-256', 'secret', 'salt', 1e3, 32);
 crypto.PBKDF2('SHA-384', 'secret', 'salt', 10e3, 32);

--- a/types/crypto.ts
+++ b/types/crypto.ts
@@ -1,10 +1,15 @@
 import * as crypto from 'worktop/crypto';
+import { toHEX } from 'worktop/utils';
 
 declare let i8: Int8Array;
 declare let u8: Uint8Array;
 declare let u32: Uint32Array;
 declare let ab: ArrayBuffer;
 declare let dv: DataView;
+
+/**
+ * timingSafeEqual
+ */
 
 assert<Function>(crypto.timingSafeEqual);
 assert<boolean>(crypto.timingSafeEqual(u8, u8));
@@ -19,3 +24,66 @@ crypto.timingSafeEqual(ab, i8);
 
 // @ts-expect-error - Mismatch
 crypto.timingSafeEqual(u8, u32);
+
+/**
+ * digest
+ */
+
+// @ts-expect-error
+crypto.digest('foobar', 'message');
+
+assert<Promise<string>>(
+	crypto.digest('SHA-1', 'foobar')
+);
+
+assert<string>(
+	await crypto.digest('SHA-1', 'foobar')
+);
+
+/**
+ * HMAC
+ */
+
+// @ts-expect-error
+crypto.HMAC('foobar', 'secret', 'data');
+
+crypto.HMAC('SHA-1', 'secret', 'data');
+crypto.HMAC('SHA-256', 'secret', 'data');
+crypto.HMAC('SHA-384', 'secret', 'data');
+crypto.HMAC('SHA-512', 'secret', 'data');
+
+assert<Promise<ArrayBuffer>>(
+	crypto.HMAC('SHA-1', 'secret', 'data')
+);
+
+assert<ArrayBuffer>(
+	await crypto.HMAC('SHA-1', 'secret', 'data')
+);
+
+assert<string>(
+	await crypto.HMAC('SHA-256', 'secret', 'data').then(toHEX)
+);
+
+/**
+ * PBKDF2
+ */
+
+// @ts-expect-error
+crypto.PBKDF2('foobar', 'secret', 'salt', 1e3, 32);
+
+crypto.PBKDF2('SHA-1', 'secret', 'salt', 1e3, 32);
+crypto.PBKDF2('SHA-256', 'secret', 'salt', 1e3, 32);
+crypto.PBKDF2('SHA-384', 'secret', 'salt', 10e3, 32);
+crypto.PBKDF2('SHA-512', 'secret', 'salt', 1e3, 32);
+
+assert<Promise<ArrayBuffer>>(
+	crypto.PBKDF2('SHA-512', 'secret', 'salt', 1e3, 32)
+);
+
+assert<ArrayBuffer>(
+	await crypto.PBKDF2('SHA-512', 'secret', 'salt', 1e3, 32)
+);
+
+assert<string>(
+	await crypto.PBKDF2('SHA-1', 'secret', 'salt', 1e3, 32).then(toHEX)
+);


### PR DESCRIPTION
> Related #30 

Gotta test if Cloudflare Workers actually allows the `MD5` algorithm for *all* digest methods, or only for the `crypto.subtle.digest` function specifically.

> See https://developers.cloudflare.com/workers/runtime-apis/web-crypto#supported-algorithms