### PR TITLE
feat: mount Router to route prefix

### DIFF
--- a/packages/worktop/src/router.d.ts
+++ b/packages/worktop/src/router.d.ts
@@ -89,7 +89,7 @@ export type Initializer<C extends Context> = (
 ) => Promise<Response>;
 
 export declare class Router<C extends Context = Context> {
-	mount(prefix: string, router: Router<C>): void;
+	mount(prefix: `/${string}/`, router: Router<C>): void;
 	add<T extends RegExp>(method: Method, route: T, handler: Handler<C, Params>): void;
 	add<T extends string>(method: Method, route: T, handler: Handler<C, Strict<RouteParams<T>>>): void;
 	onerror(req: Request, context: C & { status?: number; error?: Error }): Promisable<Response>;

--- a/packages/worktop/src/router.d.ts
+++ b/packages/worktop/src/router.d.ts
@@ -89,6 +89,7 @@ export type Initializer<C extends Context> = (
 ) => Promise<Response>;
 
 export declare class Router<C extends Context = Context> {
+	mount(prefix: string, router: Router<C>): void;
 	add<T extends RegExp>(method: Method, route: T, handler: Handler<C, Params>): void;
 	add<T extends string>(method: Method, route: T, handler: Handler<C, Strict<RouteParams<T>>>): void;
 	onerror(req: Request, context: C & { status?: number; error?: Error }): Promisable<Response>;

--- a/packages/worktop/src/router.ts
+++ b/packages/worktop/src/router.ts
@@ -1,8 +1,9 @@
 import { parse } from 'regexparam';
 import { finalize, STATUS_CODES } from 'worktop/response';
 
-import type { Handler, Deferral, Router as RR } from 'worktop';
+import type { Handler, Deferral } from 'worktop';
 import type { Method, Params, Context } from 'worktop';
+import type { Initializer, Router as RR } from 'worktop';
 import type { Dict } from 'worktop/utils';
 
 type HC = Handler;
@@ -33,6 +34,7 @@ interface Branch {
 
 type Tree = Partial<Record<Method, Branch>>;
 type Route = { params: Params; handler: HC };
+type Mounts = Dict<Initializer<Context>>;
 
 function find(tree: Tree, method: Method, pathname: string): Route|void {
 	let params: Params = {};
@@ -61,7 +63,7 @@ function find(tree: Tree, method: Method, pathname: string): Route|void {
 }
 
 export function Router(): RR<Context> {
-	let $: RR<Context>, tree: Tree = {};
+	let $: RR<Context>, tree: Tree = {}, mounts: Mounts = {};
 
 	return $ = {
 		add(method: Method, route: RegExp | string, handler: HC) {
@@ -84,6 +86,12 @@ export function Router(): RR<Context> {
 			}
 		},
 
+		mount(prefix, router) {
+			if (!prefix.endsWith('/')) prefix += '/';
+			if (!prefix.startsWith('/')) prefix = '/' + prefix;
+			mounts[prefix] = router.run;
+		},
+
 		onerror(req, context) {
 			let { error, status=500 } = context;
 			let body = error && error.message || STATUS_CODES[status];
@@ -102,8 +110,16 @@ export function Router(): RR<Context> {
 
 				var res = $.prepare && await $.prepare(req, context as PC);
 				if (res && res instanceof Response) return res;
+				let tmp, path = context.url.pathname;
 
-				let tmp = find(tree, req.method as Method, context.url.pathname);
+				for (tmp in mounts) {
+					if (path.startsWith(tmp)) {
+						context.url.pathname = path.substring(tmp.length);
+						return mounts[tmp](new Request(context.url.href, req), context);
+					}
+				}
+
+				tmp = find(tree, req.method as Method, path);
 				if (!tmp) return (context as EC).status=404, res=await $.onerror(req, context as Context);
 
 				context.params = tmp.params;

--- a/packages/worktop/src/router.ts
+++ b/packages/worktop/src/router.ts
@@ -114,7 +114,7 @@ export function Router(): RR<Context> {
 				if (mounts) for (tmp in mounts) {
 					if (x.startsWith(tmp)) {
 						context.url.pathname = path.substring(tmp.length) || '/';
-						return mounts[tmp](new Request(context.url.href, req), context);
+						return res = await mounts[tmp](new Request(context.url.href, req), context);
 					}
 				}
 

--- a/packages/worktop/src/router.ts
+++ b/packages/worktop/src/router.ts
@@ -110,8 +110,8 @@ export function Router(): RR<Context> {
 				var res = $.prepare && await $.prepare(req, context as PC);
 				if (res && res instanceof Response) return res;
 
-				let tmp, path = context.url.pathname, x = path + '/';
-				if (mounts) for (tmp in mounts) {
+				let tmp, path = context.url.pathname, x = path+'/';
+				if (mounts && path.length > 1) for (tmp in mounts) {
 					if (x.startsWith(tmp)) {
 						context.url.pathname = path.substring(tmp.length) || '/';
 						return res = await mounts[tmp](new Request(context.url.href, req), context);

--- a/packages/worktop/src/router.ts
+++ b/packages/worktop/src/router.ts
@@ -88,8 +88,6 @@ export function Router(): RR<Context> {
 
 		mount(prefix, router) {
 			mounts = mounts || {};
-			if (!prefix.endsWith('/')) prefix += '/';
-			if (!prefix.startsWith('/')) prefix = '/' + prefix;
 			mounts[prefix] = router.run;
 		},
 

--- a/packages/worktop/src/router.ts
+++ b/packages/worktop/src/router.ts
@@ -63,7 +63,7 @@ function find(tree: Tree, method: Method, pathname: string): Route|void {
 }
 
 export function Router(): RR<Context> {
-	let $: RR<Context>, tree: Tree = {}, mounts: Mounts = {};
+	let $: RR<Context>, mounts: Mounts, tree: Tree = {};
 
 	return $ = {
 		add(method: Method, route: RegExp | string, handler: HC) {
@@ -87,6 +87,7 @@ export function Router(): RR<Context> {
 		},
 
 		mount(prefix, router) {
+			mounts = mounts || {};
 			if (!prefix.endsWith('/')) prefix += '/';
 			if (!prefix.startsWith('/')) prefix = '/' + prefix;
 			mounts[prefix] = router.run;
@@ -112,7 +113,7 @@ export function Router(): RR<Context> {
 				if (res && res instanceof Response) return res;
 				let tmp, path = context.url.pathname;
 
-				for (tmp in mounts) {
+				if (mounts) for (tmp in mounts) {
 					if (path.startsWith(tmp)) {
 						context.url.pathname = path.substring(tmp.length);
 						return mounts[tmp](new Request(context.url.href, req), context);

--- a/packages/worktop/src/router.ts
+++ b/packages/worktop/src/router.ts
@@ -109,11 +109,11 @@ export function Router(): RR<Context> {
 
 				var res = $.prepare && await $.prepare(req, context as PC);
 				if (res && res instanceof Response) return res;
-				let tmp, path = context.url.pathname;
 
+				let tmp, path = context.url.pathname, x = path + '/';
 				if (mounts) for (tmp in mounts) {
-					if (path.startsWith(tmp)) {
-						context.url.pathname = path.substring(tmp.length);
+					if (x.startsWith(tmp)) {
+						context.url.pathname = path.substring(tmp.length) || '/';
 						return mounts[tmp](new Request(context.url.href, req), context);
 					}
 				}

--- a/packages/worktop/types/router.ts
+++ b/packages/worktop/types/router.ts
@@ -257,4 +257,11 @@ API.prepare = (req, res) => 123;
 // @ts-expect-error
 API.mount(/foo/, API);
 
+// @ts-expect-error
+API.mount('foo/', API);
+
+// @ts-expect-error
+API.mount('/foo', API);
+
 API.mount('/foo/', API);
+API.mount('/foo/bar/', API);

--- a/packages/worktop/types/router.ts
+++ b/packages/worktop/types/router.ts
@@ -249,3 +249,12 @@ API.prepare = function (req, res) {
 
 // @ts-expect-error - numerical
 API.prepare = (req, res) => 123;
+
+/**
+ * MOUNT
+ */
+
+// @ts-expect-error
+API.mount(/foo/, API);
+
+API.mount('/foo/', API);


### PR DESCRIPTION
> Closes #29 

This feature allows you to mount a `Router` to a parent `Router` under a prefix. This is a familiar approach and organizational technique for those familiar with Polka or Express. With these Node.js frameworks, you'll often see this pattern:

```js
import Polka from 'polka';
import Items from './apps/items';
import Users from './apps/users';

Polka()
  .use(/* global middleware */)
  // Mount child routers
  .use('/users/', Users)
  .use('/items', Items)
  // Primary application route(
  .get('/:name', (req, res) => { 
    // ...
  })
  // initialize
  .listen(3000);
```

The benefit of this approach is/was that you can build a self-contained `Users` application separately from your `Items` application. Each of these are actually *blissfully unaware* of the fact that they're running under the `/items/` or `/users/` URL namespaces. As far as each application is concerned, it's built/served at the apex. For example, the `Items` Polka sub-router/sup-application would look something like this:

```js
// apps/items.js
import Polka from 'polka';

const App = Polka().use(
  // any shared middleware for this app
);

App.get('/', async  (req, res) => { ... });
App.get('/:title', async (req, res) => { ... });
App.post('/', async (req, res) => { ... });

export default App;
```

None of its routes include the `/items/` prefix because it was the Parent/Main application's decision to place it there. It wasn't a part of `Items` routing requirements. Instead, all routes within `Items` are checked against the incoming URL – sans the `/items/` prefix because the Parent/Main application has already matched & claimed that portion.

This allows `Items` and `Users` to be entirely self-contained. And, as a nice side effect, means that `Users` and `Items` can be mounted _anywhere_ or even be deployed as their own, standalone endpoints (no prefix).

---

I explain all this because this PR now unlocks the same approach and organizational patterns!

Coming from the Polka / Express background, the only differences are that:

1. In worktop, we use `.mount()` instead of `.use()`
2. Unlike `.use()`, the `.mount()` function only accepts a **static** `prefix` string and another `Router`

For example, these Express patterns are **not allowed** in Worktop:

```js
import express from 'express';
import Items from './routes/items';

// Missing "prefix"
express().use(Items);

// Pointless "prefix"
express().use('/', Items);

// Must be static "prefix" route
express().use('/api/:version', Items);

// Cannot use RegExp
express().use(/^[/]foobar[/]?/, Items);
```

Instead, here is the correct way to use worktop child routers – and the _only_ way~!

```ts
import { Router } from 'worktop';
import { send } from 'worktop/response';
// NOTE:  could be any init approach
import { reply } from 'worktop/sw';

// Imported child router(s)
import { Items } from './routes/items';
import { Users } from './routes/users';

const API = new Router;

// global middleware
API.prepare = function (req, ctx) {
  console.log('API@prepare', req.url);

  // sees *all* outgoing responses
  ctx.defer(res => {
    console.log('API@prepare.defer');
    res.headers.set('x-global', 'yes');
  });
};

// Direct all "/items/*" routes to `Items` router
API.mount('/items/', Items);

// "/users/*" -> Users router
API.mount('/users/', Users);

// Never sees "/items/*" or "/users/*" routes
API.add('GET', '/:name', (req, ctx) => { 
  console.log('~> inside API@show handler');
  return send(200, `API @ GET /:name -> ${ctx.params.name}`);
});

// initialize
reply(API.run);
```

The `Items` and `Users` imports here are constructed exactly the same way – and can even `.mount()` their own child routers!

```ts
// routes/items.js
import { Router } from 'worktop';
import { send } from 'worktop/response';

// Imported its own child router(s)
import { Other } from './other';

// NOTE: exported 
export const Items = new Router;

// Mount its own child router
Items.mount('/other/', Other);

// shared middleware for all Items routes
Items.prepare = function (req, ctx) {
  console.log('Items@prepare', req.url);

  // sees *all* outgoing responses for this router
  ctx.defer(res => {
    console.log('Items@prepare.defer');
    res.headers.set('x-items', 'yes');
  });
};

// will *never* see the "/items/" prefix
Items.add('GET', '/', (req) => {
  console.log('~> inside items@root handler');
  return send(200, 'Items @ GET /');
});

// will *never* see the "/items/" prefix
Items.add('GET', '/:title', (req, ctx) => {
  console.log('~> inside items@show handler');
  return send(200, `Items @ GET /:title -> ${ctx.params.title}`);
});
```

So there's a bit going on here, but when looking at each Router individually, it all makes sense and is only concerned with what it directly owns.

Topographically, the parent `API` is the main/top-level router. It's always the first thing to see a request and the last one to touch a response (via `context.defer`). So when a `GET /items` request arrives, the `API.prepare` function runs immediately & then passes off the _modified_ `Request` (removing the `'/items/'` prefix from the URL) to the `Items` router. At that point, the `Request` belongs entirely to the `Items` router – if it has no route matches & decides to send a `404` response, then that's what will be returned to the client.

> **Important:** Unlike Express, worktop **does not** continue looping through all route handlers to find a match. Any `mount()`ed router owns its matched request.

If a mounted router is forwarded a `Request`, the associated `context.params` and `context.url` are reset.

Once a `Response` is returned from the `Items` router, then any of its `context.defer`s are applied to the response, followed by any `context.defer`s that were queued within the `API` parent router.

Here are some quick routing outputs for the above example application:

```
GET /hello
(log) API@prepare https://.../hello
(log) ~> inside API@show handler
(log) API@prepare.defer
(200) "API @ GET /:name -> hello"
(header) x-global: yes


GET /items
(log) API@prepare https://.../items
(log) Items@prepare https://.../
(log) ~> inside items@root handler
(log) Items@prepare.defer
(log) API@prepare.defer
(200) "Items @ GET /"
(header) x-items: yes
(header) x-global: yes


GET /items/foobar
(log) API@prepare https://.../items/foobar
(log) Items@prepare https://.../foobar
(log) ~> inside items@show handler
(log) Items@prepare.defer
(log) API@prepare.defer
(200) "Items @ GET /:title -> foobar"
(header) x-items: yes
(header) x-global: yes


GET /items/other/howdy
(log) API@prepare https://.../items/other/howdy
(log) Items@prepare https://.../other/howdy
(???) < Other.prepare, if defined >
(???) < Other route handler(s) >
(???) < Other context.defers, if any >
(log) Items@prepare.defer
(log) API@prepare.defer
(???) < Other response content >
(header) x-items: yes
(header) x-global: yes
```