### PR TITLE
fix(crypto): correct encodings

### DIFF
--- a/packages/worktop/src/crypto.test.ts
+++ b/packages/worktop/src/crypto.test.ts
@@ -1,9 +1,11 @@
 import { suite } from 'uvu';
 import { promisify } from 'util';
 import * as assert from 'uvu/assert';
-import { createHash, pbkdf2 } from 'crypto';
+import { createHash, createHmac, pbkdf2 } from 'crypto';
 import * as crypto from './crypto';
 import { toHEX } from './buffer';
+
+import type { Algorithms } from './crypto.d';
 
 const digest = suite('digest');
 
@@ -20,144 +22,100 @@ digest.run();
 
 // ---
 
-const SHA1 = suite('SHA1');
+const SHA1 = suite('SHA1', {
+	async compare(input: string) {
+		assert.is(
+			await crypto.SHA1(input),
+			createHash('sha1').update(input).digest('hex'),
+			`~> "${input}"`
+		);
+	}
+});
 
 SHA1('should be a function', () => {
 	assert.type(crypto.SHA1, 'function');
 });
 
-SHA1('should return correct values as hexstrings', async () => {
-	assert.is(
-		await crypto.SHA1(''),
-		createHash('sha1').update('').digest('hex'),
-		'~> da39a3ee5e6b4b0d3255bfef95601890afd80709'
-	);
-
-	assert.is(
-		await crypto.SHA1('hello'),
-		createHash('sha1').update('hello').digest('hex'),
-		'~> aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d'
-	);
-
-	assert.is(
-		await crypto.SHA1('hello1'),
-		createHash('sha1').update('hello1').digest('hex'),
-		'~> 88fdd585121a4ccb3d1540527aee53a77c77abb8'
-	);
-
-	assert.is(
-		await crypto.SHA1('hello world'),
-		createHash('sha1').update('hello world').digest('hex'),
-		'~> 2aae6c35c94fcfb415dbe95f408b9ce91ee846ed'
-	);
+SHA1('should return correct values as hexstrings', async ctx => {
+	await ctx.compare('');
+	await ctx.compare('hello');
+	await ctx.compare('hello123');
+	await ctx.compare('"foo … bar"');
 });
 
 SHA1.run();
 
 // ---
 
-const SHA256 = suite('SHA256');
+const SHA256 = suite('SHA256', {
+	async compare(input: string) {
+		assert.is(
+			await crypto.SHA256(input),
+			createHash('sha256').update(input).digest('hex'),
+			`~> "${input}"`
+		);
+	}
+});
 
 SHA256('should be a function', () => {
 	assert.type(crypto.SHA256, 'function');
 });
 
-SHA256('should return correct values as hexstrings', async () => {
-	assert.is(
-		await crypto.SHA256(''),
-		createHash('sha256').update('').digest('hex'),
-		'~> e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
-	);
-
-	assert.is(
-		await crypto.SHA256('hello'),
-		createHash('sha256').update('hello').digest('hex'),
-		'~> 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824'
-	);
-
-	assert.is(
-		await crypto.SHA256('hello1'),
-		createHash('sha256').update('hello1').digest('hex'),
-		'~> 91e9240f415223982edc345532630710e94a7f52cd5f48f5ee1afc555078f0ab'
-	);
-
-	assert.is(
-		await crypto.SHA256('hello world'),
-		createHash('sha256').update('hello world').digest('hex'),
-		'~> b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9'
-	);
+SHA256('should return correct values as hexstrings', async ctx => {
+	await ctx.compare('');
+	await ctx.compare('hello');
+	await ctx.compare('hello123');
+	await ctx.compare('"foo … bar"');
 });
 
 SHA256.run();
 
 // ---
 
-const SHA384 = suite('SHA384');
+const SHA384 = suite('SHA384', {
+	async compare(input: string) {
+		assert.is(
+			await crypto.SHA384(input),
+			createHash('sha384').update(input).digest('hex'),
+			`~> "${input}"`
+		);
+	}
+});
 
 SHA384('should be a function', () => {
 	assert.type(crypto.SHA384, 'function');
 });
 
-SHA384('should return correct values as hexstrings', async () => {
-	assert.is(
-		await crypto.SHA384(''),
-		createHash('sha384').update('').digest('hex'),
-		'~> 38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b'
-	);
-
-	assert.is(
-		await crypto.SHA384('hello'),
-		createHash('sha384').update('hello').digest('hex'),
-		'~> 59e1748777448c69de6b800d7a33bbfb9ff1b463e44354c3553bcdb9c666fa90125a3c79f90397bdf5f6a13de828684f'
-	);
-
-	assert.is(
-		await crypto.SHA384('hello1'),
-		createHash('sha384').update('hello1').digest('hex'),
-		'~> 7a79ada28c7218353974345bfc7c2c463577219dc4ecc155341e770ce235634c7f5224bf586e51fe6d890cfe41e1c59a'
-	);
-
-	assert.is(
-		await crypto.SHA384('hello world'),
-		createHash('sha384').update('hello world').digest('hex'),
-		'~> fdbd8e75a67f29f701a4e040385e2e23986303ea10239211af907fcbb83578b3e417cb71ce646efd0819dd8c088de1bd'
-	);
+SHA384('should return correct values as hexstrings', async ctx => {
+	await ctx.compare('');
+	await ctx.compare('hello');
+	await ctx.compare('hello123');
+	await ctx.compare('"foo … bar"');
 });
 
 SHA384.run();
 
 // ---
 
-const SHA512 = suite('SHA512');
+const SHA512 = suite('SHA512', {
+	async compare(input: string) {
+		assert.is(
+			await crypto.SHA512(input),
+			createHash('sha512').update(input).digest('hex'),
+			`~> "${input}"`
+		);
+	}
+});
 
 SHA512('should be a function', () => {
 	assert.type(crypto.SHA512, 'function');
 });
 
-SHA512('should return correct values as hexstrings', async () => {
-	assert.is(
-		await crypto.SHA512(''),
-		createHash('sha512').update('').digest('hex'),
-		'~> cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e'
-	);
-
-	assert.is(
-		await crypto.SHA512('hello'),
-		createHash('sha512').update('hello').digest('hex'),
-		'~> 9b71d224bd62f3785d96d46ad3ea3d73319bfbc2890caadae2dff72519673ca72323c3d99ba5c11d7c7acc6e14b8c5da0c4663475c2e5c3adef46f73bcdec043'
-	);
-
-	assert.is(
-		await crypto.SHA512('hello1'),
-		createHash('sha512').update('hello1').digest('hex'),
-		'~> 1dabfeadb6451e4903649fe6efec8ecda6b40e5ba99f73dfb5510956df496ecb1ebb625b9376bbcef223b354481633e9b977872aef979478e6451975e714c31f'
-	);
-
-	assert.is(
-		await crypto.SHA512('hello world'),
-		createHash('sha512').update('hello world').digest('hex'),
-		'~> 309ecc489c12d6eb4cc40f50c902f2b4d0ed77ee511a7c7a9bcd3ca86d4cd86f989dd35bc5ff499670da34255b45b0cfd830e81f605dcf7dc5542e93ae9cd76f'
-	);
+SHA512('should return correct values as hexstrings', async ctx => {
+	await ctx.compare('');
+	await ctx.compare('hello');
+	await ctx.compare('hello123');
+	await ctx.compare('"foo … bar"');
 });
 
 SHA512.run();
@@ -248,27 +206,34 @@ timingSafeEqual.run();
 // ---
 
 const PBKDF2 = suite('PBKDF2', {
-	native: promisify(pbkdf2)
+	async compare(payload: string, salt: string) {
+		// @see https://nodejs.org/api/crypto.html#crypto_crypto_pbkdf2_password_salt_iterations_keylen_digest_callback
+		let nodejs = await promisify(pbkdf2)(payload, salt, 100e3, 64, 'sha512');
+		let web = toHEX(await crypto.PBKDF2('SHA-512', payload, salt, 100e3, 64));
+		assert.is(web, nodejs.toString('hex'), `~> "${ payload }"`);
+	}
 });
 
 PBKDF2('should be a function', () => {
 	assert.type(crypto.PBKDF2, 'function');
 });
 
-// @see https://nodejs.org/api/crypto.html#crypto_crypto_pbkdf2_password_salt_iterations_keylen_digest_callback
 PBKDF2('should produce expected output', async ctx => {
-	assert.is(
-		await crypto.PBKDF2('SHA-512', 'secret', 'salt', 100e3, 64).then(toHEX),
-		(await ctx.native('secret', 'salt', 100e3, 64, 'sha512')).toString('hex'),
-		'~> 3745e482c6e0ade35da10139e797157f4a5da669dad7d5da88ef87e47471cc47ed941c7ad618e827304f083f8707f12b7cfdd5f489b782f10cc269e3c08d59ae'
-	)
+	await ctx.compare('secret123', 'salt');
+	await ctx.compare('foo … bar', 'salt123');
 });
 
 PBKDF2.run();
 
 // ---
 
-const HMAC = suite('HMAC');
+const HMAC = suite('HMAC', {
+	async compare(algo: Algorithms.Digest, payload: string, secret: string) {
+		let native = createHmac(algo.replace('-', '').toLowerCase(), secret).update(payload).digest('hex');
+		let output = await crypto.HMAC(algo, secret, payload).then(toHEX);
+		assert.is(output, native, `~> "${payload}"`);
+	}
+});
 
 HMAC('should be a function', () => {
 	assert.type(crypto.HMAC, 'function');
@@ -282,42 +247,36 @@ HMAC('should return ArrayBuffer', async () => {
 	assert.instance(output, ArrayBuffer);
 });
 
-HMAC('should produce expected output :: SHA-1', async () => {
-	let foo = await crypto.HMAC('SHA-1', 'hello', 'world').then(toHEX);
-	assert.is(foo, '8a3a84bcd0d0065e97f175d370447c7d02e00973');
+HMAC('should produce expected output :: SHA-1', async ctx => {
+	await ctx.compare('SHA-1', 'hello', 'world');
+	await ctx.compare('SHA-1', 'world', 'world');
 
-	let bar = await crypto.HMAC('SHA-1', 'world', 'hello').then(toHEX);
-	assert.is(bar, '5a0c67d922de0ca53e306250e6858c1f6d2c4943');
+	await ctx.compare('SHA-1', 'foo … bar', 'password');
+	await ctx.compare('SHA-1', '😂', 'password');
 });
 
-HMAC('should produce expected output :: SHA-256', async () => {
-	let foo = await crypto.HMAC('SHA-256', 'hello', 'world').then(toHEX);
-	assert.is(foo, 'f1ac9702eb5faf23ca291a4dc46deddeee2a78ccdaf0a412bed7714cfffb1cc4');
-	assert.is(foo, await crypto.HMAC256('hello', 'world').then(toHEX));
+HMAC('should produce expected output :: SHA-256', async ctx => {
+	await ctx.compare('SHA-256', 'hello', 'world');
+	await ctx.compare('SHA-256', 'world', 'world');
 
-	let bar = await crypto.HMAC('SHA-256', 'world', 'hello').then(toHEX);
-	assert.is(bar, '3cfa76ef14937c1c0ea519f8fc057a80fcd04a7420f8e8bcd0a7567c272e007b');
-	assert.is(bar, await crypto.HMAC256('world', 'hello').then(toHEX));
+	await ctx.compare('SHA-256', 'foo … bar', 'password');
+	await ctx.compare('SHA-256', '😂', 'password');
 });
 
-HMAC('should produce expected output :: SHA-384', async () => {
-	let foo = await crypto.HMAC('SHA-384', 'hello', 'world').then(toHEX);
-	assert.is(foo, '80d036d9974e6f71ceabe493ee897d00235edcc4c72e046ddfc8bf68e86a477d63b9f7d26ad5b990aae6ac17db57ddcf');
-	assert.is(foo, await crypto.HMAC384('hello', 'world').then(toHEX));
+HMAC('should produce expected output :: SHA-384', async ctx => {
+	await ctx.compare('SHA-384', 'hello', 'world');
+	await ctx.compare('SHA-384', 'world', 'world');
 
-	let bar = await crypto.HMAC('SHA-384', 'world', 'hello').then(toHEX);
-	assert.is(bar, '2dc82db49e763d4f589d6b79c788a66ca27a708e8fba0014c36519f4c48e9cb5651d8c86ea6ca0c760219ac3bc009cf8');
-	assert.is(bar, await crypto.HMAC384('world', 'hello').then(toHEX));
+	await ctx.compare('SHA-384', 'foo … bar', 'password');
+	await ctx.compare('SHA-384', '😂', 'password');
 });
 
-HMAC('should produce expected output :: SHA-512', async () => {
-	let foo = await crypto.HMAC('SHA-512', 'hello', 'world').then(toHEX);
-	assert.is(foo, '6668ed2f7d016c5f12d7808fc4f2d1dc4851622d7f15616de947a823b3ee67d761b953f09560da301f832902020dd1c64f496df37eb7ac4fd2feeeb67d77ba9b');
-	assert.is(foo, await crypto.HMAC512('hello', 'world').then(toHEX));
+HMAC('should produce expected output :: SHA-512', async ctx => {
+	await ctx.compare('SHA-512', 'hello', 'world');
+	await ctx.compare('SHA-512', 'world', 'world');
 
-	let bar = await crypto.HMAC('SHA-512', 'world', 'hello').then(toHEX);
-	assert.is(bar, '2b83319d3e78544e4430c4f5621968fee8b6ffa1254678b2c6fb98f7f79ff16afee2da909a7bb741488ca3bacbbf6cec8fd226c5a52eef805ea65a352e2ece8e');
-	assert.is(bar, await crypto.HMAC512('world', 'hello').then(toHEX));
+	await ctx.compare('SHA-512', 'foo … bar', 'password');
+	await ctx.compare('SHA-512', '😂', 'password');
 });
 
 HMAC.run();

--- a/packages/worktop/src/crypto.ts
+++ b/packages/worktop/src/crypto.ts
@@ -1,8 +1,8 @@
-import { encode, toHEX } from 'worktop/buffer';
+import { asUTF8, toHEX } from 'worktop/buffer';
 import type { Algorithms, TypedArray } from 'worktop/crypto';
 
 export function digest(algo: Algorithms.Digest, message: string): Promise<string> {
-	return crypto.subtle.digest(algo, encode(message)).then(toHEX);
+	return crypto.subtle.digest(algo, asUTF8(message)).then(toHEX);
 }
 
 export const MD5    = /*#__PURE__*/ digest.bind(0, 'MD5');
@@ -12,7 +12,7 @@ export const SHA384 = /*#__PURE__*/ digest.bind(0, 'SHA-384');
 export const SHA512 = /*#__PURE__*/ digest.bind(0, 'SHA-512');
 
 export function keyload(algo: Algorithms.Keying, secret: string, scopes: KeyUsage[]): Promise<CryptoKey> {
-	return crypto.subtle.importKey('raw', encode(secret), algo, false, scopes);
+	return crypto.subtle.importKey('raw', asUTF8(secret), algo, false, scopes);
 }
 
 export function keygen(algo: Algorithms.Keying, scopes: KeyUsage[], extractable = false): Promise<CryptoKey|CryptoKeyPair> {
@@ -20,11 +20,11 @@ export function keygen(algo: Algorithms.Keying, scopes: KeyUsage[], extractable 
 }
 
 export function sign(algo: Algorithms.Signing, key: CryptoKey, payload: string): Promise<ArrayBuffer> {
-	return crypto.subtle.sign(algo, key, encode(payload));
+	return crypto.subtle.sign(algo, key, asUTF8(payload));
 }
 
 export function verify(algo: Algorithms.Signing, key: CryptoKey, payload: string, signature: ArrayBuffer): Promise<boolean> {
-	return crypto.subtle.verify(algo, key, signature, encode(payload));
+	return crypto.subtle.verify(algo, key, signature, asUTF8(payload));
 }
 
 export function timingSafeEqual<T extends TypedArray>(a: T, b: T): boolean {
@@ -42,7 +42,7 @@ export async function PBKDF2(digest: Algorithms.Digest, password: string, salt: 
 
 	const algo: Pbkdf2Params = {
 		name: 'PBKDF2',
-		salt: encode(salt),
+		salt: asUTF8(salt),
 		iterations: iters,
 		hash: digest,
 	};

--- a/packages/worktop/src/internal/jwt.ts
+++ b/packages/worktop/src/internal/jwt.ts
@@ -13,12 +13,30 @@ export const EXPIRED = /*#__PURE__*/ new Error('Expired token');
 
 // type: helper
 export function encode(input: object) {
-	return Base64.base64url(JSON.stringify(input));
+	return Base64.base64url(
+		buff.toBinary(
+			buff.asUTF8(
+				JSON.stringify(input)
+			)
+		)
+	);
 }
 
 // type: helper
 export function toASCII(input: ArrayBuffer): string {
-	return Base64.base64url(buff.toBinary(input));
+	return Base64.base64url(
+		buff.toBinary(input)
+	);
+}
+
+// type: helper
+// Convert base64 string into JSON w/ UTF8 values
+function toJSON<T>(input: string): T {
+	return JSON.parse(
+		buff.toUTF8(
+			buff.asBinary(input)
+		)
+	);
 }
 
 // type: external
@@ -32,8 +50,9 @@ export function decode<P,H>(input: string): {
 
 	try {
 		let payload = Base64.decode(segs[1]);
-		var hh = JSON.parse(Base64.decode(segs[0]));
-		var pp = hh.typ === 'JWT' ? JSON.parse(payload) : payload;
+		var hh = toJSON<JWT.Header<H>>(Base64.decode(segs[0]));
+		// var pp = hh.typ === 'JWT' ? toJSON<JWT.Payload<P>>(payload) : payload;
+		var pp = toJSON<JWT.Payload<P>>(payload);
 	} catch (e) {
 		throw INVALID;
 	}

--- a/packages/worktop/src/jwt.test.ts
+++ b/packages/worktop/src/jwt.test.ts
@@ -63,6 +63,36 @@ HS256('should sign a JWT input', async () => {
 	assert.ok(output);
 });
 
+HS256('should sign a JWT input :: utf8', async () => {
+	let ctx = jwt.HS256({
+		key: 'foo…bar'
+	});
+
+	let token = await ctx.sign({
+		iat: 1516239022,
+		// @ts-ignore
+		foo: 'foo…bar'
+	});
+
+	// note: confirm via jwt.io
+	assert.is(token, 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE1MTYyMzkwMjIsImZvbyI6ImZvb-KApmJhciJ9.HGeqRU6wp5JzQw1WupljtZPU_KDe-d86GHzqUUlAMCU');
+
+	assert.equal(jwt.decode(token), {
+		header: {
+			alg: 'HS256',
+			typ: 'JWT',
+		},
+		payload: {
+			iat: 1516239022,
+			foo: 'foo…bar',
+		},
+		signature: 'HGeqRU6wp5JzQw1WupljtZPU_KDe-d86GHzqUUlAMCU',
+	});
+
+	let output = await ctx.verify(token);
+	assert.ok(output);
+});
+
 HS256('should sign a JWT input :: expires', async () => {
 	let ctx = jwt.HS256({
 		key: 'secret',
@@ -171,9 +201,7 @@ HS256('should sign a JWT input :: header claims', async () => {
 	});
 });
 
-// TODO: verify tests
-// TODO: HS384,512 tests
-
+// TODO: verify
 HS256.run();
 
 // ---
@@ -279,6 +307,36 @@ RS256('should sign a JWT input', async () => {
 			iat: 1516239022,
 		},
 		signature: 'S5Ap_Bq-a4elbpIfmLiEER8jlkbjl8FgEyxHtgsq1ukRdHvKXt6zeR0h3zo0k4APCEky7VAyF9vaUZl7c-8iJ35Sk8z5w8hXCrf7-s7kEw6t9_ypNjZjst36JhOkrBw1SPQv3Dh9Ekjbqem5zywAhCAeynvRawk9vx6vXKFgyNQQCjRniPbAab8prk75M2zSA9DIMiDwb33ywFF-TP89vHuZhF_ekiA_M03Gw-Tgq0REx7i3NlKQw6YIfO3J3H1GNShoytD2ln45qo4FnfWXUxRxmEWpP6ZQrLHUC9EPay9ollPMQqWfB3oBAw1bIrZc0_glWpNBPl1UaQq0mRhzqg',
+	});
+
+	let output = await ctx.verify(token);
+	assert.ok(output);
+});
+
+RS256('should sign a JWT input :: utf8', async () => {
+	let ctx = jwt.RS256({
+		privkey: '-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDowizjrc4us3A9\n7Jpcc2Aq7zgitEh4XSpoc+k4bokIPLWxXcgk2Iyx15UWdUM3bGpKmh1qnIjpDOun\n8SEWSAQec1pwnpw59VhdF0wfDALyb8sxAQlR4IJh/mj52MOHgonBn1qPz88tWk6Z\nG2lXV2aIPfQiisv/wzrir9pSKyUQnLu//LG3+X7rG0FKt7CKuSUKzhy23hFwI5Xq\napDDRXOb/M5Glp0fwPplcV17bP163bM0EDLVV9kuCBHgZdVwlzrHV2N30c4QPz14\nJ/ox+AEXkgDTQAcJOM+X1sjg/zGdyCMIfYtQKHCOD6aLr9ADqpQsgqC00t+qWDQX\nZMnoKycxAgMBAAECggEALzjv8wxY47Qvjjyxz5Zv2R4aET5q4pKiTzlPBI42eoeY\npEC+4azWlKFEo98MEVNLWFHerHnQNBoVOIgtGpBnV4c3PtiLIR4j/JUEslrVQTsJ\nqipH6gbm5PtA8Im4F8bV7ITIUpuKcKzc++aqD1iR2ovZO2XWABCrooCjhl6vASis\nPsjwues5juGfSfCGSDem/VnmLPdQwdLLTjAZyzMo70q6rI/F/4JA9yxO/T1KTPre\njUhVnGBVp8y4Fp+NP3XJGLM+nYtrYCO9svgHwThQgZcnFNTUBMo9JYOVxTEoLwek\nZ9H5J865KddAT4W46D7xpq1XH07eQ6U2ggshrt+NHQKBgQD7LAl5UwM87nCF+yhn\nheU3wrSSohCVQGio1UK/v5x5z3WztfB2k0/hSdlc9gZn9r714l+jfSWDoJuUNAvM\nCXJ1D9v6KvGH1sgOAXZTtAJ9Ib1ntaOrtHZ9awP7lI8pDkx5XaMlnf2uGSkt+Kqt\nKZSPq/mosrT316154IP2l8MIDQKBgQDtO4eGfU8ajIG35ZswdNADsVUJgjdIq8A8\n040F6ZY619m56VO61EWdS2AzvoaCrlDWLqBYfyl7VINBbVd+MJy01108JSj/GwTG\nOD7WTubr9wffLzhKEWj2MPLpURkwGU7hWDWnnCI4oP4XmTlQior3M0t2Xc/hEI2V\njjRvNvzOtQKBgDu44dvOSEPRskG5UYckCDe0/TisfmLuuLQEWWW8itlP4f3EMhQP\nvPulkqCPA0DvI8LVe8Yk+KmOo8+efHucd3GsPrMCSQHyqQjjgh4u/DSCtEWXo/4s\n38u8iWrljRDHDJoDEMreATbHVspOiU65R1DOJIPfUjZoOyByqQ4WUdJ1AoGBAOZC\nwKGmYTBYrtPK9d2LlBfxeKOZE4Xixt2DTL8vYZTNy9PqiE2wGb252q9+v1p6TZYG\nfbZH/wBpIFlSAvlFv+S7oRBu1SL/m5u2Hi+vN+5SwP48+/rQeTt0eWJDSBpqhiit\nkK6WGpUylk5bd8kYIBgeXqGOHubKRVKjS3ujOLB9AoGAN22NQaoCHQbEcDDZUkce\nDD61Y1Q5iIlgzQv+lhobnXJJXYvmLffC8CVqGxU+jkm4+ogaK/7DQneWus1EjpoG\nseXY6tNuyp1RKKGW9aZbbI/SLWrvz+irdxgFX8Y45Ms9Mlzp5P2ixaRYI3SJJSv9\nrEmDzIuJyVuZWb8UrFbANdQ=\n-----END PRIVATE KEY-----',
+		pubkey: '-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA6MIs463OLrNwPeyaXHNg\nKu84IrRIeF0qaHPpOG6JCDy1sV3IJNiMsdeVFnVDN2xqSpodapyI6Qzrp/EhFkgE\nHnNacJ6cOfVYXRdMHwwC8m/LMQEJUeCCYf5o+djDh4KJwZ9aj8/PLVpOmRtpV1dm\niD30IorL/8M64q/aUislEJy7v/yxt/l+6xtBSrewirklCs4ctt4RcCOV6mqQw0Vz\nm/zORpadH8D6ZXFde2z9et2zNBAy1VfZLggR4GXVcJc6x1djd9HOED89eCf6MfgB\nF5IA00AHCTjPl9bI4P8xncgjCH2LUChwjg+mi6/QA6qULIKgtNLfqlg0F2TJ6Csn\nMQIDAQAB\n-----END PUBLIC KEY-----',
+	});
+
+	let token = await ctx.sign({
+		iat: 1516239022,
+		// @ts-ignore
+		foo: "foo…bar"
+	});
+
+	assert.is(token, 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE1MTYyMzkwMjIsImZvbyI6ImZvb-KApmJhciJ9.LtJmpBY4miI98MfVGWXx4MOpHV4F8qg5Pec4OaMyHiL36yeSwyoDAz-8McjXECa4EaADsbMu_1CSabjJI_doDVRVdCE-AWQT2UPY5Zfuk2BcX4Eepz54jlwsNnqoX8STkfdoQl21LcujXPb-nPTS0zY-p8L57MclaV3T2wizG-ckkoafqsMvgr22_LGkdf3d0ZiEUbAE3K2gG-D_mLu2Oy3BphBahWGT-BKliZee8ycQLfhfE6KJEekF9yf08xyKoiiAGkNobW6unJpwwLqhdCJf5dDsQ0yKLsk5RJAIYBASMtkJNhEqI3nLR1X9Z_r7XHxgT1ke8eF8WG2aBxrnjw');
+
+	assert.equal(jwt.decode(token), {
+		header: {
+			alg: 'RS256',
+			typ: 'JWT',
+		},
+		payload: {
+			iat: 1516239022,
+			foo: "foo…bar"
+		},
+		signature: 'LtJmpBY4miI98MfVGWXx4MOpHV4F8qg5Pec4OaMyHiL36yeSwyoDAz-8McjXECa4EaADsbMu_1CSabjJI_doDVRVdCE-AWQT2UPY5Zfuk2BcX4Eepz54jlwsNnqoX8STkfdoQl21LcujXPb-nPTS0zY-p8L57MclaV3T2wizG-ckkoafqsMvgr22_LGkdf3d0ZiEUbAE3K2gG-D_mLu2Oy3BphBahWGT-BKliZee8ycQLfhfE6KJEekF9yf08xyKoiiAGkNobW6unJpwwLqhdCJf5dDsQ0yKLsk5RJAIYBASMtkJNhEqI3nLR1X9Z_r7XHxgT1ke8eF8WG2aBxrnjw',
 	});
 
 	let output = await ctx.verify(token);


### PR DESCRIPTION
An unintended consequence of #89 (specifically https://github.com/lukeed/worktop/pull/89/commits/2b2943166443f0fe3527efac4251f45992713d2b) was that the `worktop/crypto` utilities moved from `utf8`-based to `binary`-based encoding. This PR reverts that change, which is necessary because it's how/what all HMAC/Digest/etc functions expect to work with.

While investing this, I noticed that the `workop/jwt` module wasn't properly enforcing the UTF8 encoding either (where necessary).