### PR TITLE
break(cache): replace `start` init -> `sync` handler;

### DIFF
--- a/examples/workers/basic-module/index.ts
+++ b/examples/workers/basic-module/index.ts
@@ -1,6 +1,8 @@
 import { Router } from 'worktop';
 import * as Cache from 'worktop/cache';
 import { reply } from 'worktop/response';
+import { start } from 'worktop/cfw';
+
 import type { Context } from 'worktop';
 
 interface Custom extends Context {
@@ -10,6 +12,8 @@ interface Custom extends Context {
 }
 
 const API = new Router<Custom>();
+
+API.prepare = Cache.sync();
 
 API.add('GET', '/greet/:name?', (req, context) => {
 	let name = context.params.name || context.bindings.FALLBACK;
@@ -25,4 +29,5 @@ API.add('GET', '/', (req, context) => {
 	});
 });
 
-export default Cache.start(API.run);
+// Module Worker
+export default start(API.run);

--- a/examples/workers/basic/index.ts
+++ b/examples/workers/basic/index.ts
@@ -1,8 +1,11 @@
 import { Router } from 'worktop';
 import * as Cache from 'worktop/cache';
 import { reply } from 'worktop/response';
+import { listen } from 'worktop/cfw';
 
 const API = new Router();
+
+API.prepare = Cache.sync();
 
 API.add('GET', '/greet/:name', (req, context) => {
 	return new Response(`Hello, ${context.params.name}!`);
@@ -17,13 +20,5 @@ API.add('GET', '/', (req, context) => {
 	});
 });
 
-// NOTE: manual because SW is not assumed
-addEventListener('fetch', event => {
-	event.respondWith(
-		Cache.lookup(event.request).then(prev => {
-			return prev || API.run(event.request, event).then(res => {
-				return Cache.save(event.request, res, event);
-			});
-		})
-	);
-});
+// Service Worker
+listen(API.run);

--- a/examples/workers/kv-todos/index.ts
+++ b/examples/workers/kv-todos/index.ts
@@ -1,10 +1,13 @@
 import { Router } from 'worktop';
 import * as Cache from 'worktop/cache';
+import { start } from 'worktop/cfw';
 import * as Todos from './routes';
 
 import type { Context } from './types';
 
 const API = new Router<Context>();
+
+API.prepare = Cache.sync();
 
 /**
  * NOTE: Demo expects hard-coded ":username" value.
@@ -16,4 +19,4 @@ API.add('PUT', '/users/:username/todos/:uid', Todos.update);
 API.add('DELETE', '/users/:username/todos/:uid', Todos.destroy);
 
 // Module Worker
-export default Cache.start(API.run);
+export default start(API.run);

--- a/examples/workers/ws/index.ts
+++ b/examples/workers/ws/index.ts
@@ -1,5 +1,5 @@
 import { Router } from 'worktop';
-import * as sworker from 'worktop/sw';
+import { start } from 'worktop/sw';
 import * as ws from 'worktop/ws';
 
 const API = new Router;
@@ -199,6 +199,5 @@ API.add('GET', '/', (req, context) => {
 	});
 });
 
-// Format: Service Worker
-// Wraps w/ addEventListener('fetch', ...)
-sworker.start(API.run);
+// Service Worker
+start(API.run);

--- a/packages/worktop/src/cache.d.ts
+++ b/packages/worktop/src/cache.d.ts
@@ -1,19 +1,20 @@
 /// <reference lib="webworker" />
 
-import type { Context, Initializer } from 'worktop';
-import type { Bindings, Module, FetchHandler } from 'worktop/cfw';
+import type { Module } from 'worktop/cfw';
+import type { Context, Params } from 'worktop';
+import type { Strict } from 'worktop/utils';
 
 export const Cache: Cache;
 export function save(req: Request | string, res: Response, context: Module.Context): Response;
 export function lookup(request: Request | string): Promise<Response | void>;
 export function isCacheable(res: Response): boolean;
 
-/**
- * Attempt to `lookup` the `event.request`, otherwise run the `handler` and attempt to `save` the Response.
- */
-export function start<
+export function sync(): <
 	C extends Context = Context,
-	B extends Bindings = Bindings,
->(run: Initializer<C>): {
-	fetch: FetchHandler<B>;
-}
+	P extends Params = Params,
+>(
+	request: Request,
+	context: Omit<C, 'params'> & {
+		params: Strict<P & C['params']>;
+	}
+) => Response | void;

--- a/packages/worktop/src/cfw.d.ts
+++ b/packages/worktop/src/cfw.d.ts
@@ -15,6 +15,10 @@ declare global {
 		};
 	};
 
+	interface CacheStorage {
+		default: Cache;
+	}
+
 	interface Request {
 		cf: IncomingCloudflareProperties;
 	}

--- a/packages/worktop/types/cache.ts
+++ b/packages/worktop/types/cache.ts
@@ -1,6 +1,7 @@
+import { compose } from 'worktop';
 import * as Cache from 'worktop/cache';
 import type { Module } from 'worktop/cfw';
-import type { Router } from 'worktop';
+import type { Router, Handler } from 'worktop';
 
 declare const event: FetchEvent;
 declare const request: Request;
@@ -68,11 +69,27 @@ Cache.isCacheable(123);
 Cache.isCacheable(request);
 
 /**
- * REPLY
+ * sync
  */
 
-assert<Module.Worker>(
-	Cache.start(API.run)
+assert<Handler>(
+	Cache.sync()
+);
+
+
+/**
+ * ROUTER
+ */
+
+// @ts-expect-error
+API.prepare = Cache.sync;
+API.prepare = Cache.sync();
+
+API.prepare = compose(
+	Cache.sync(),
+	async (req, res) => {
+		return new Response
+	}
 );
 
 /**

--- a/packages/worktop/types/demo.ts
+++ b/packages/worktop/types/demo.ts
@@ -5,6 +5,7 @@ import { read, write } from 'worktop/kv';
 import { Router, compose } from 'worktop';
 import { reply } from 'worktop/response';
 import * as utils from 'worktop/utils';
+import { start } from 'worktop/cfw';
 
 import type { Context } from 'worktop';
 import type { ULID } from 'worktop/utils';
@@ -41,6 +42,9 @@ API.prepare = compose(
 			res.headers.set('x-response-time', ms);
 		});
 	},
+
+	// Attach `Cache` lookup -> save
+	Cache.sync(),
 
 	// Attach global CORS config
 	CORS.preflight({
@@ -106,4 +110,4 @@ API.add('POST', '/accounts', async (req, context) => {
 });
 
 // Initialize: Module Worker
-export default Cache.start(API.run);
+export default start(API.run);

--- a/packages/worktop/types/init.ts
+++ b/packages/worktop/types/init.ts
@@ -3,8 +3,8 @@ import * as cfw from 'worktop/cfw';
 import * as sw from 'worktop/sw';
 
 import type { Strict } from 'worktop/utils';
-import type { Bindings, CronEvent, Module } from 'worktop/cfw';
 import type { Context, Router } from 'worktop';
+import type { Bindings, CronEvent, Module } from 'worktop/cfw';
 
 declare const API: Router;
 declare const CUSTOM: Router<MyContext>;
@@ -32,18 +32,6 @@ assert<void>(
 
 assert<void>(
 	cfw.listen(CUSTOM.run)
-);
-
-/**
- * init: Cache
- */
-
-assert<Module.Worker>(
-	Cache.start(API.run)
-);
-
-assert<Module.Worker>(
-	Cache.start(CUSTOM.run)
 );
 
 /**
@@ -129,15 +117,14 @@ addEventListener('fetch', event => {
 	)
 });
 
-const worker1 = cfw.start(API.run);
-const worker2 = Cache.start(API.run);
+const worker = cfw.start(API.run);
 
 addEventListener('fetch', event => {
 	let req = event.request;
 	let bindings: Bindings = {};
 	event.respondWith((async function () {
-		let res = await worker1.fetch(req, bindings, event);
-		return res || worker2.fetch(req, bindings, event);
+		let res = await worker.fetch(req, bindings, event);
+		return res || fetch(req);
 	})());
 });
 

--- a/packages/worktop/types/router.strict.ts
+++ b/packages/worktop/types/router.strict.ts
@@ -1,4 +1,5 @@
-import { Router } from 'worktop';
+import * as Cache from 'worktop/cache';
+import { Router, compose } from 'worktop';
 import * as modules from 'worktop/cfw';
 import * as sw from 'worktop/sw';
 
@@ -19,9 +20,12 @@ interface Custom extends Context {
 
 const API = new Router<Custom>();
 
-API.prepare = function (req, context) {
-	context.start = Date.now();
-};
+API.prepare = compose(
+	Cache.sync(),
+	function (req, context) {
+		context.start = Date.now();
+	},
+);
 
 API.add('GET', '/:foo/:bar?', async (req, context) => {
 	assert<Custom>(context);

--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,7 @@ import * as utils from 'worktop/utils';
 import { read, write } from 'worktop/kv';
 import { reply } from 'worktop/response';
 import * as Cache from 'worktop/cache';
+import { start } from 'worktop/cfw';
 
 import type { KV } from 'worktop/kv';
 import type { Context } from 'worktop';
@@ -64,9 +65,13 @@ interface Message {
   // ...
 }
 
-// Initialize
+// Create new Router instance
 const API = new Router<Bindings>();
 
+// Any `prepare` logic runs 1st for every request, before routing
+// ~> use `Cache` for request-matching, when permitted
+// ~> store Response in `Cache`, when permitted
+API.prepare = Cache.sync();
 
 API.add('GET', '/messages/:id', async (req, context) => {
   // Pre-parsed `context.params` object
@@ -124,10 +129,8 @@ API.add('POST', '/messages', async (req, context) => {
 });
 
 
-// Attach "fetch" event handler
-// ~> use `Cache` for request-matching, when permitted
-// ~> store Response in `Cache`, when permitted
-export default Cache.start(API.run);
+// Init: Module Worker
+export default start(API.run);
 ```
 
 ## API


### PR DESCRIPTION
When putting together #127, I had written this: https://github.com/lukeed/worktop/issues/125#issuecomment-1003230020 :

> TLDR; make the `start` export from `worktop/cache` be the only done-for-you solution & have it target Module Workers (Cloudflare only), which is fine since worktop still is primarily a framework for Cloudflare Workers.

This forced me to write this bit: https://github.com/lukeed/worktop/pull/127/files#diff-f3d34dc7f4bb98b62c70ef1556b3d53c7343467844228b39a8a16ebf0b6bc997R20 ... which wasn't _terrible_ but alarmingly different than using the rest of worktop.

So after looking at it for a bit, I realized that this `Cache.lookup() -> Cache.save()?` chain is just a standard `Handler` type. And, more specifically, it should be run as a `Router.prepare` hook (just like `CORS.preflight`) because it needs to do some work immediately upfront & the bulk of its work _after_ `Router.run` has executed – this is exactly what `context.defer` was made for!

This PR removes the `Cache.start` method altogether (recently renamed from `Cache.reply`) and instead offers up a `Cache.sync` utility that's meant to be used as (or within) your Router's `prepare` hook:

Here's a before/after of a simple Module Worker that would have used `Cache.start` (or `Cache.reply`) previously:

```ts
/// BEFORE
/// ---
import { Router } from 'worktop';
import * as Cache from 'worktop/cache';

const API = new Router;

// routes

export default Cache.start(API.run);

/// AFTER
/// ---
import { Router } from 'worktop';
import { start } from 'worktop/cfw';
import * as Cache from 'worktop/cache';

const API = new Router;

API.prepare = Cache.sync();

// routes

export default start(API.run);
```

The `Cache.sync` factory returns a standard `Handler`, which means you can `compose()` it with other `Handler`s for a final `prepare` hook:

```ts
import { Router, compose } from 'worktop';
import * as Cache from 'worktop/cache';
import * as CORS from 'worktop/cors';
import { start } from 'worktop/cfw';

const API = new Router;

API.prepare = compose(
  Cache.sync(),
  CORS.preflight(),
);

// ...

export default start(API.run);
```