### PR TITLE
wip: begin `create-worktop` package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ node_modules
 !/packages/worktop/src/
 !/packages/worktop/types/
 
-/packages/worktop.build/index.js
-/packages/worktop.build/index.mjs
+/packages/*/index.js
+/packages/*/index.mjs
 
 /examples/build

--- a/bin/index.js
+++ b/bin/index.js
@@ -149,5 +149,6 @@ async function bundle(modname, isMulti = true) {
  */
 Promise.all([
 	bundle('worktop', true),
+	bundle('create-worktop', false),
 	bundle('worktop.build', false),
 ]);

--- a/bin/index.js
+++ b/bin/index.js
@@ -71,7 +71,20 @@ async function bundle(modname, isMulti = true) {
 		else if (!key) key = './' + file.replace(isTS, '');
 
 		let entry = pkg.exports[key];
-		if (!entry) return bail(`Missing "exports" entry: ${key}`);
+
+		if (!entry) {
+			if (typeof pkg.exports === 'string') {
+				let isCJS = /\.c?js$/.test(pkg.exports);
+				entry = { [isCJS ? 'require' : 'import']: pkg.exports };
+			} else if (pkg.exports.require || pkg.exports.import) {
+				entry = pkg.exports;
+			} else {
+				return bail(`Missing "exports" entry: ${key}`);
+			}
+
+			entry.import = entry.import || './fake.mjs';
+		}
+
 		if (!entry.import) return bail(`Missing "import" condition: ${key}`);
 		if (!entry.require) return bail(`Missing "require" condition: ${key}`);
 
@@ -110,7 +123,7 @@ async function bundle(modname, isMulti = true) {
 
 			// create dir (safe writes)
 			if (isMulti) await fs.promises.mkdir(outdir);
-			await write(esm.path, esm.contents);
+			esm.path.endsWith('fake.mjs') || await write(esm.path, esm.contents);
 
 			// convert esm -> cjs
 			output = join(pkgdir, entry.require);

--- a/packages/create-worktop/bin.js
+++ b/packages/create-worktop/bin.js
@@ -3,8 +3,11 @@ const argv = require('mri')(process.argv.slice(2), {
 	alias: {
 		C: 'cwd',
 		f: 'force',
+		t: 'typescript',
+		// m: 'monorepo',
 		v: 'version',
 		h: 'help',
+		c: 'cfw',
 	},
 	default: {
 		C: '.',
@@ -26,10 +29,13 @@ if (argv.help) {
 	output += '\n    npm init worktop <name> [options]';
 	output += '\n';
 	output += '\n  Options';
-	output += '\n    -C, --cwd        Directory to resolve from';
-	output += '\n    -f, --force      Force directory overwrite';
-	output += '\n    -v, --version    Displays current version';
-	output += '\n    -h, --help       Displays this message';
+	output += '\n    -C, --cwd          Directory to resolve from';
+	output += '\n    -f, --force        Force directory overwrite';
+	output += '\n    -t, --typescript   Force directory overwrite';
+	// output += '\n    -m, --monorepo     Force directory overwrite';
+	output += '\n    -c, --cfw          Force directory overwrite';
+	output += '\n    -v, --version      Displays current version';
+	output += '\n    -h, --help         Displays this message';
 	output += '\n';
 	output += '\n  Examples';
 	output += '\n    $ npm init worktop my-worker';

--- a/packages/create-worktop/bin.js
+++ b/packages/create-worktop/bin.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+const argv = require('mri')(process.argv.slice(2), {
+	alias: {
+		C: 'cwd',
+		f: 'force',
+		v: 'version',
+		h: 'help',
+	},
+	default: {
+		C: '.',
+		f: false,
+	}
+});
+
+/** @param {string} msg */
+function exit(msg, code = 1) {
+	if (code) process.stderr.write(msg + '\n');
+	else process.stdout.write(msg + '\n');
+	process.exit(code);
+}
+
+if (argv.help) {
+	let output = '';
+
+	output += '\n  Usage';
+	output += '\n    npm init worktop <name> [options]';
+	output += '\n';
+	output += '\n  Options';
+	output += '\n    -C, --cwd        Directory to resolve from';
+	output += '\n    -f, --force      Force directory overwrite';
+	output += '\n    -v, --version    Displays current version';
+	output += '\n    -h, --help       Displays this message';
+	output += '\n';
+	output += '\n  Examples';
+	output += '\n    $ npm init worktop my-worker';
+	output += '\n    $ yarn create worktop my-worker --force';
+	output += '\n';
+
+	exit(output, 0);
+}
+
+if (argv.version) {
+	console.log('TODO, v0.0.0');
+}
+
+(async function () {
+	try {
+		let dir = argv._.join('-').trim().replace(/[\s_]+/g, '-');
+		if (!dir) return exit('Missing <name> argument', 1);
+		await require('.').setup(dir, argv);
+	} catch (err) {
+		exit(err.stack, 1);
+	}
+})();

--- a/packages/create-worktop/package.json
+++ b/packages/create-worktop/package.json
@@ -1,0 +1,26 @@
+{
+  "version": "0.0.4",
+  "name": "create-worktop",
+  "repository": "lukeed/worktop",
+  "description": "wip",
+  "license": "MIT",
+  "bin": "bin.js",
+  "author": {
+    "name": "Luke Edwards",
+    "email": "luke.edwards05@gmail.com",
+    "url": "https://lukeed.com"
+  },
+  "exports": "./index.js",
+  "files": [
+    "bin.js",
+    "index.js",
+    "template"
+  ],
+  "engines": {
+    "node": ">=12"
+  },
+  "dependencies": {
+    "kleur": "^4.0.0",
+    "mri": "^1.2.0"
+  }
+}

--- a/packages/create-worktop/src/index.ts
+++ b/packages/create-worktop/src/index.ts
@@ -5,6 +5,8 @@ interface Argv {
 	cwd: string;
 	force?: boolean;
 	typescript?: boolean;
+	// TODO: monorepo
+	// TODO: env+format combos
 }
 
 async function mkdir(dir: string) {

--- a/packages/create-worktop/src/index.ts
+++ b/packages/create-worktop/src/index.ts
@@ -1,0 +1,60 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+interface Argv {
+	cwd: string;
+	force?: boolean;
+}
+
+async function mkdir(dir: string) {
+	fs.existsSync(dir) || await fs.promises.mkdir(dir, { recursive: true });
+}
+
+// @modified lukeed/totalist
+type Caller = (abs: string, rel: string, isDir: boolean) => Promise<void>;
+async function list(dir: string, callback: Caller, prefix = '') {
+	let files = await fs.promises.readdir(dir, { withFileTypes: true });
+
+	await Promise.all(
+		files.map(async dirent => {
+			let rel = path.join(prefix, dirent.name);
+			let item = path.join(dir, dirent.name);
+			let isDir = dirent.isDirectory();
+
+			await callback(item, rel, isDir);
+			if (isDir) return list(item, callback, rel);
+		})
+	);
+}
+
+async function copy(src: string, dest: string) {
+	// "foo/_gitignore" => "foo/.gitignore"
+	dest = dest.replace(/([\\/]+)_/, '$1.');
+	await fs.promises.copyFile(src, dest);
+}
+
+export async function setup(dir: string, argv: Argv) {
+	argv.cwd = path.resolve(argv.cwd || '.');
+
+	let source = path.join(__dirname, 'template', 'root');
+	let target = path.join(argv.cwd, dir);
+
+	if (fs.existsSync(target) && !argv.force) {
+		let pretty = path.relative(process.cwd(), target);
+		let msg = `Refusing to overwrite existing "${pretty}" directory.\n`;
+		msg += 'Please specify a different directory or use the `--force` flag.';
+		throw new Error(msg);
+	}
+
+	await mkdir(target);
+
+	await list(source, function (abs, rel, isDir) {
+		let next = path.join(target, rel);
+		return isDir ? mkdir(next) : copy(abs, next);
+	});
+
+	await fs.promises.rename(
+		path.join(target, '.package.json'),
+		path.join(target, 'package.json'),
+	);
+}

--- a/packages/create-worktop/template/config/cfw.js
+++ b/packages/create-worktop/template/config/cfw.js
@@ -2,4 +2,5 @@
  * @type {import('cfw').Config}
  */
 module.exports = {
+	// TODO
 }

--- a/packages/create-worktop/template/config/cfw.js
+++ b/packages/create-worktop/template/config/cfw.js
@@ -1,0 +1,5 @@
+/**
+ * @type {import('cfw').Config}
+ */
+module.exports = {
+}

--- a/packages/create-worktop/template/config/wrangler.toml
+++ b/packages/create-worktop/template/config/wrangler.toml
@@ -1,0 +1,11 @@
+type = "javascript"
+account_id = "<YOUR ACCOUNT ID>"
+zone_id = "<YOUR ZONE ID>"
+
+[build]
+command = "npm run build"
+
+[build.upload]
+format = "modules"
+main = "./index.mjs"
+dir = "build"

--- a/packages/create-worktop/template/index.js
+++ b/packages/create-worktop/template/index.js
@@ -1,0 +1,87 @@
+import { HS256 } from 'worktop/jwt';
+import * as CORS from 'worktop/cors';
+import * as Cache from 'worktop/cache';
+import { Router, compose } from 'worktop';
+import { read, write } from 'worktop/kv';
+import { send } from 'worktop/response';
+import * as utils from 'worktop/utils';
+
+// Create new Router
+const API = new Router;
+
+API.prepare = compose(
+	// Attach global middleware
+	(req, context) => {
+		context.timestamp = Date.now();
+
+		context.defer(res => {
+			let ms = Date.now() - context.timestamp;
+			res.headers.set('x-response-time', ms);
+		});
+	},
+
+	// Attach global CORS config
+	CORS.preflight({
+		maxage: 3600 * 6, // 6 hr
+		credentials: true,
+	})
+);
+
+API.add('GET', '/', () => {
+	return send(200, 'OK');
+});
+
+API.add('GET', '/accounts/:uid', async (req, context) => {
+	try {
+		let item = await read(context.bindings.ACCOUNT, context.params.uid);
+		if (!item) return send(404, 'Unknown account identifier');
+		return send(200, item, {
+			'Cache-Control': 'public,max-age=900'
+		});
+	} catch (err) {
+		return send(500, 'Error retrieving account');
+	}
+});
+
+API.add('POST', '/accounts', async (req, context) => {
+	try {
+		var input = await utils.body(req);
+		if (input == null) return send(400, 'Missing request body');
+	} catch (err) {
+		return send(500, 'Error parsing request');
+	}
+
+	try {
+		var values = {
+			uid: utils.ulid(),
+			name: input.name || '',
+			email: input.email || '',
+		};
+
+		let isOK = await write(context.bindings.ACCOUNT, values.uid, values);
+		if (!isOK) return send(400, 'Error saving account');
+	} catch (err) {
+		return send(500, 'Error creating account');
+	}
+
+	try {
+		let JWT = HS256({
+			key: context.bindings.JWT_KEY,
+			iss: context.bindings.JWT_ISS,
+			expires: 3600 * 3, // 3 hours
+		});
+
+		let token = await JWT.sign({
+			uid: values.uid,
+			email: values.email,
+		});
+
+		return send(201, { token, values });
+	} catch (err) {
+		await context.bindings.ACCOUNT.delete(values.uid);
+		return send(500, 'Error signing token');
+	}
+});
+
+// Initialize: Module Worker
+export default Cache.reply(API.run);

--- a/packages/create-worktop/template/index.js
+++ b/packages/create-worktop/template/index.js
@@ -1,13 +1,14 @@
 import { HS256 } from 'worktop/jwt';
 import * as CORS from 'worktop/cors';
 import * as Cache from 'worktop/cache';
-import { Router, compose } from 'worktop';
 import { read, write } from 'worktop/kv';
-import { send } from 'worktop/response';
+import { Router, compose } from 'worktop';
+import { reply } from 'worktop/response';
 import * as utils from 'worktop/utils';
+import { start } from 'worktop/cfw';
 
 // Create new Router
-const API = new Router;
+const API = new Router();
 
 API.prepare = compose(
 	// Attach global middleware
@@ -20,6 +21,9 @@ API.prepare = compose(
 		});
 	},
 
+	// Attach `Cache` lookup -> save
+	Cache.sync(),
+
 	// Attach global CORS config
 	CORS.preflight({
 		maxage: 3600 * 6, // 6 hr
@@ -28,27 +32,27 @@ API.prepare = compose(
 );
 
 API.add('GET', '/', () => {
-	return send(200, 'OK');
+	return reply(200, 'OK');
 });
 
 API.add('GET', '/accounts/:uid', async (req, context) => {
 	try {
 		let item = await read(context.bindings.ACCOUNT, context.params.uid);
-		if (!item) return send(404, 'Unknown account identifier');
-		return send(200, item, {
+		if (!item) return reply(404, 'Unknown account identifier');
+		return reply(200, item, {
 			'Cache-Control': 'public,max-age=900'
 		});
 	} catch (err) {
-		return send(500, 'Error retrieving account');
+		return reply(500, 'Error retrieving account');
 	}
 });
 
 API.add('POST', '/accounts', async (req, context) => {
 	try {
 		var input = await utils.body(req);
-		if (input == null) return send(400, 'Missing request body');
+		if (input == null) return reply(400, 'Missing request body');
 	} catch (err) {
-		return send(500, 'Error parsing request');
+		return reply(500, 'Error parsing request');
 	}
 
 	try {
@@ -59,9 +63,9 @@ API.add('POST', '/accounts', async (req, context) => {
 		};
 
 		let isOK = await write(context.bindings.ACCOUNT, values.uid, values);
-		if (!isOK) return send(400, 'Error saving account');
+		if (!isOK) return reply(400, 'Error saving account');
 	} catch (err) {
-		return send(500, 'Error creating account');
+		return reply(500, 'Error creating account');
 	}
 
 	try {
@@ -76,12 +80,12 @@ API.add('POST', '/accounts', async (req, context) => {
 			email: values.email,
 		});
 
-		return send(201, { token, values });
+		return reply(201, { token, values });
 	} catch (err) {
 		await context.bindings.ACCOUNT.delete(values.uid);
-		return send(500, 'Error signing token');
+		return reply(500, 'Error signing token');
 	}
 });
 
 // Initialize: Module Worker
-export default Cache.reply(API.run);
+export default start(API.run);

--- a/packages/create-worktop/template/index.ts
+++ b/packages/create-worktop/template/index.ts
@@ -1,10 +1,11 @@
 import { HS256 } from 'worktop/jwt';
 import * as CORS from 'worktop/cors';
 import * as Cache from 'worktop/cache';
-import { Router, compose } from 'worktop';
 import { read, write } from 'worktop/kv';
-import { send } from 'worktop/response';
+import { Router, compose } from 'worktop';
+import { reply } from 'worktop/response';
 import * as utils from 'worktop/utils';
+import { start } from 'worktop/cfw';
 
 import type { Context } from 'worktop';
 import type { ULID } from 'worktop/utils';
@@ -42,6 +43,9 @@ API.prepare = compose(
 		});
 	},
 
+	// Attach `Cache` lookup -> save
+	Cache.sync(),
+
 	// Attach global CORS config
 	CORS.preflight({
 		maxage: 3600 * 6, // 6 hr
@@ -50,27 +54,27 @@ API.prepare = compose(
 );
 
 API.add('GET', '/', () => {
-	return send(200, 'OK');
+	return reply(200, 'OK');
 });
 
 API.add('GET', '/accounts/:uid', async (req, context) => {
 	try {
 		let item = await read<Account>(context.bindings.ACCOUNT, context.params.uid);
-		if (!item) return send(404, 'Unknown account identifier');
-		return send(200, item, {
+		if (!item) return reply(404, 'Unknown account identifier');
+		return reply(200, item, {
 			'Cache-Control': 'public,max-age=900'
 		});
 	} catch (err) {
-		return send(500, 'Error retrieving account');
+		return reply(500, 'Error retrieving account');
 	}
 });
 
 API.add('POST', '/accounts', async (req, context) => {
 	try {
 		var input = await utils.body<Account>(req);
-		if (input == null) return send(400, 'Missing request body');
+		if (input == null) return reply(400, 'Missing request body');
 	} catch (err) {
-		return send(500, 'Error parsing request');
+		return reply(500, 'Error parsing request');
 	}
 
 	try {
@@ -81,9 +85,9 @@ API.add('POST', '/accounts', async (req, context) => {
 		};
 
 		let isOK = await write<Account>(context.bindings.ACCOUNT, values.uid, values);
-		if (!isOK) return send(400, 'Error saving account');
+		if (!isOK) return reply(400, 'Error saving account');
 	} catch (err) {
-		return send(500, 'Error creating account');
+		return reply(500, 'Error creating account');
 	}
 
 	try {
@@ -98,12 +102,12 @@ API.add('POST', '/accounts', async (req, context) => {
 			email: values.email,
 		});
 
-		return send(201, { token, values });
+		return reply(201, { token, values });
 	} catch (err) {
 		await context.bindings.ACCOUNT.delete(values.uid);
-		return send(500, 'Error signing token');
+		return reply(500, 'Error signing token');
 	}
 });
 
 // Initialize: Module Worker
-export default Cache.reply(API.run);
+export default start(API.run);

--- a/packages/create-worktop/template/index.ts
+++ b/packages/create-worktop/template/index.ts
@@ -1,0 +1,109 @@
+import { HS256 } from 'worktop/jwt';
+import * as CORS from 'worktop/cors';
+import * as Cache from 'worktop/cache';
+import { Router, compose } from 'worktop';
+import { read, write } from 'worktop/kv';
+import { send } from 'worktop/response';
+import * as utils from 'worktop/utils';
+
+import type { Context } from 'worktop';
+import type { ULID } from 'worktop/utils';
+import type { KV } from 'worktop/kv';
+
+interface Custom extends Context {
+	timestamp: number;
+	bindings: {
+		JWT_KEY: string;
+		JWT_ISS: string;
+		ACCOUNT: KV.Namespace;
+	};
+}
+
+interface Account {
+	uid: ULID;
+	name: string;
+	email: string;
+	// ...
+}
+
+type TokenPayload = Pick<Account, 'uid' | 'email'>;
+
+// Create new Router
+const API = new Router<Custom>();
+
+API.prepare = compose(
+	// Attach global middleware
+	(req, context) => {
+		context.timestamp = Date.now();
+
+		context.defer(res => {
+			let ms = Date.now() - context.timestamp;
+			res.headers.set('x-response-time', ms);
+		});
+	},
+
+	// Attach global CORS config
+	CORS.preflight({
+		maxage: 3600 * 6, // 6 hr
+		credentials: true,
+	})
+);
+
+API.add('GET', '/', () => {
+	return send(200, 'OK');
+});
+
+API.add('GET', '/accounts/:uid', async (req, context) => {
+	try {
+		let item = await read<Account>(context.bindings.ACCOUNT, context.params.uid);
+		if (!item) return send(404, 'Unknown account identifier');
+		return send(200, item, {
+			'Cache-Control': 'public,max-age=900'
+		});
+	} catch (err) {
+		return send(500, 'Error retrieving account');
+	}
+});
+
+API.add('POST', '/accounts', async (req, context) => {
+	try {
+		var input = await utils.body<Account>(req);
+		if (input == null) return send(400, 'Missing request body');
+	} catch (err) {
+		return send(500, 'Error parsing request');
+	}
+
+	try {
+		var values: Account = {
+			uid: utils.ulid(),
+			name: input.name || '',
+			email: input.email || '',
+		};
+
+		let isOK = await write<Account>(context.bindings.ACCOUNT, values.uid, values);
+		if (!isOK) return send(400, 'Error saving account');
+	} catch (err) {
+		return send(500, 'Error creating account');
+	}
+
+	try {
+		let JWT = HS256<TokenPayload>({
+			key: context.bindings.JWT_KEY,
+			iss: context.bindings.JWT_ISS,
+			expires: 3600 * 3, // 3 hours
+		});
+
+		let token = await JWT.sign({
+			uid: values.uid,
+			email: values.email,
+		});
+
+		return send(201, { token, values });
+	} catch (err) {
+		await context.bindings.ACCOUNT.delete(values.uid);
+		return send(500, 'Error signing token');
+	}
+});
+
+// Initialize: Module Worker
+export default Cache.reply(API.run);

--- a/packages/create-worktop/template/root/_editorconfig
+++ b/packages/create-worktop/template/root/_editorconfig
@@ -1,0 +1,13 @@
+# http://editorconfig.org
+root = true
+
+[*]
+indent_size = 2
+indent_style = tab
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{json,yml,yaml,md}]
+indent_style = space

--- a/packages/create-worktop/template/root/_gitignore
+++ b/packages/create-worktop/template/root/_gitignore
@@ -1,0 +1,5 @@
+node_modules
+.DS_Store
+*.log
+
+/build

--- a/packages/create-worktop/template/root/_package.json
+++ b/packages/create-worktop/template/root/_package.json
@@ -1,0 +1,13 @@
+{
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "build": "worktop build"
+  },
+  "dependencies": {
+    "worktop": "next"
+  },
+  "devDependencies": {
+    "worktop.build": "latest"
+  }
+}

--- a/packages/create-worktop/template/root/_package.json
+++ b/packages/create-worktop/template/root/_package.json
@@ -2,12 +2,11 @@
   "private": true,
   "version": "0.0.0",
   "scripts": {
-    "build": "worktop build"
+    "build": "<inject>"
   },
   "dependencies": {
     "worktop": "next"
   },
   "devDependencies": {
-    "worktop.build": "latest"
   }
 }

--- a/packages/create-worktop/template/root/tsconfig.json
+++ b/packages/create-worktop/template/root/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "allowJs": true,
+    "module": "esnext",
+    "target": "es2021",
+    "noImplicitAny": true,
+    "keyofStringsOnly": true,
+    "resolveJsonModule": true,
+    "strictBindCallApply": true,
+    "forceConsistentCasingInFileNames": true,
+    "allowSyntheticDefaultImports": true,
+    "moduleResolution": "node",
+    "strictNullChecks": true,
+    "removeComments": true,
+    "sourceMap": false,
+    "checkJs": true,
+    "noEmit": true,
+  },
+  "include": [
+    "@types",
+    "src"
+  ],
+  "exclude": [
+    "build",
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
Begins a `create-worktop` package that will create a new worktop project with an example script & with `worktop.build` attached. Currently accepts a directory target & the `--typescript` flag which will determine whether or not you want to use (and be given) a TS setup.

This is still WIP as there are additional flags to be added. But will land this PR as is and add the missing pieces in future PRs since `create-worktop` and `worktop.build` must coordinate.

***Options***

- [x] `--typescript`
- [x] `--force` for directory override
- [ ] `--cfw` (or `--monorepo` ??) for monorepo/multi-worker setup
    _Should use [`cfw`](https://github.com/lukeed/cfw) to build/deploy Workers_
    * replaces `wrangler` for deployment (if `--env` is cloudflare)
    * replaces `worktop.build` for build system
- [ ] `--env` and `--format` combinations
    * `--env` – sets the platform/environment target
        * default: "cfw" | "cloudflare"
        * options: "cfw" | "cloudflare" | "browser" | "deno" | "node"
    * `--format` – depends on `--env` value
      * `"cfw"` :: "module" (default) | "sw"
      * `"browser"` :: "sw" (default)
      * `"deno"` :: N/A
      * `"node"` :: None (default) | "function" for GCP Functions | "lambda" for AWS lambda family

**Usage**

Current usage looks like this:

```sh
$ npm init worktop <dir> [flags]
# npm init worktop my-project
# npm init worktop my-ts-project --typescript
```

---

Closes #61
Closes #117 