### PR TITLE
break(ws): move `listen` and types to `cfw.ws` module;

### DIFF
--- a/examples/workers/ws/index.ts
+++ b/examples/workers/ws/index.ts
@@ -1,6 +1,6 @@
 import { Router } from 'worktop';
-import { start } from 'worktop/sw';
-import * as ws from 'worktop/ws';
+import { start } from 'worktop/cfw';
+import * as ws from 'worktop/cfw.ws';
 
 const API = new Router;
 
@@ -199,5 +199,5 @@ API.add('GET', '/', (req, context) => {
 	});
 });
 
-// Service Worker
-start(API.run);
+// Cloudflare Module Worker
+export default start(API.run);

--- a/packages/worktop/package.json
+++ b/packages/worktop/package.json
@@ -32,6 +32,10 @@
       "import": "./cfw.kv.assets/index.mjs",
       "require": "./cfw.kv.assets/index.js"
     },
+    "./cfw.ws": {
+      "import": "./cfw.ws/index.mjs",
+      "require": "./cfw.ws/index.js"
+    },
     "./cors": {
       "import": "./cors/index.mjs",
       "require": "./cors/index.js"

--- a/packages/worktop/src/cfw.d.ts
+++ b/packages/worktop/src/cfw.d.ts
@@ -3,6 +3,7 @@
 import type { Context, Initializer } from 'worktop';
 import type { Promisable, Strict } from 'worktop/utils';
 import type { Durable } from 'worktop/cfw.durable';
+import type { WebSocket } from 'worktop/cfw.ws';
 import type { KV } from 'worktop/cfw.kv';
 
 declare global {
@@ -76,15 +77,6 @@ export interface CronEvent {
 	 * Method wrapper for event's action handler.
 	 */
 	waitUntil(f: Promisable<any>): void;
-}
-
-export interface WebSocket {
-	accept(): void;
-	send(message: number | string): void;
-	close(code?: number, reason?: string): void;
-	addEventListener(type: 'error', listener: (this: WebSocket, ev: Event) => any): void;
-	addEventListener(type: 'close', listener: (this: WebSocket, ev: CloseEvent) => any): void;
-	addEventListener(type: 'message', listener: (this: WebSocket, ev: MessageEvent<string>) => any): void;
 }
 
 /**

--- a/packages/worktop/src/cfw.durable.d.ts
+++ b/packages/worktop/src/cfw.durable.d.ts
@@ -1,6 +1,6 @@
-import type { Bindings } from 'worktop';
+import type { Bindings } from 'worktop/cfw';
+import type { WebSocket } from 'worktop/cfw.ws';
 import type { Dict, Promisable } from 'worktop/utils';
-import type { WebSocket } from 'worktop/ws';
 
 export namespace Durable {
 	export interface Namespace {

--- a/packages/worktop/src/cfw.durable.ts
+++ b/packages/worktop/src/cfw.durable.ts
@@ -1,7 +1,8 @@
 import { connect } from 'worktop/ws';
+
 import type { Bindings } from 'worktop/cfw';
+import type { WebSocket } from 'worktop/cfw.ws';
 import type { Durable } from 'worktop/cfw.durable';
-import type { WebSocket } from 'worktop/ws';
 
 export abstract class Actor {
 	DEBUG: boolean;

--- a/packages/worktop/src/cfw.ws.d.ts
+++ b/packages/worktop/src/cfw.ws.d.ts
@@ -1,0 +1,55 @@
+import type { Context, Params } from 'worktop';
+import type { Dict, Strict, Promisable } from 'worktop/utils';
+
+declare global {
+	interface ResponseInit {
+		/** @note Cloudflare only */
+		webSocket?: WebSocket;
+	}
+}
+
+export interface WebSocket {
+	accept(): void;
+	send(message: number | string): void;
+	close(code?: number, reason?: string): void;
+	addEventListener(type: 'error', listener: (this: WebSocket, ev: Event) => any): void;
+	addEventListener(type: 'close', listener: (this: WebSocket, ev: CloseEvent) => any): void;
+	addEventListener(type: 'message', listener: (this: WebSocket, ev: MessageEvent<string>) => any): void;
+}
+
+export type State = Dict<any>;
+
+export interface Socket<S extends State = State> {
+	send: WebSocket['send'];
+	close: WebSocket['close'];
+	state: S; // todo: not happy w/ name
+	event:
+		| { type: 'close' } & CloseEvent
+		| { type: 'message' } & MessageEvent<string>
+		| { type: 'error' } & Event;
+}
+
+export type SocketHandler<
+	C extends Context = Context,
+	P extends Params = Params,
+	S extends State = State,
+> = (
+	request: Request,
+	context: C, // todo: omit
+	socket: Socket<S>
+) => Promisable<void>;
+
+/**
+ * Establish a Websocket connection.
+ * Attach the `handler` as the 'message' event listener.
+ * @NOTE Invokes the `connect()` middleware automatically.
+ */
+export function listen<
+	C extends Context = Context,
+	P extends Params = Params,
+>(handler: SocketHandler<C, P>): (
+ request: Request,
+ context: Omit<C, 'params'> & {
+	 params: Strict<P>;
+ }
+) => Response;

--- a/packages/worktop/src/cfw.ws.test.ts
+++ b/packages/worktop/src/cfw.ws.test.ts
@@ -1,0 +1,16 @@
+import { suite } from 'uvu';
+import * as assert from 'uvu/assert';
+import * as ws from './cfw.ws';
+
+const listen = suite('listen');
+
+listen('should be a function', () => {
+	assert.type(ws.listen, 'function');
+});
+
+listen('should return a function', () => {
+	let out = ws.listen(() => {});
+	assert.type(out, 'function');
+});
+
+listen.run();

--- a/packages/worktop/src/cfw.ws.ts
+++ b/packages/worktop/src/cfw.ws.ts
@@ -1,0 +1,47 @@
+import { connect } from 'worktop/ws';
+
+import type { Context, Params } from 'worktop';
+import type { State, SocketHandler } from 'worktop/cfw.ws';
+
+export function listen<
+	C extends Context = Context,
+	P extends Params = Params,
+	S extends State = State,
+>(handler: SocketHandler<C, P, S>): (req: Request, context: C) => Response {
+	return function (req, context) {
+		let error = connect(req);
+		if (error) return error;
+
+		let { 0: client, 1: server } = new WebSocketPair;
+
+		let state = {} as S;
+		function caller(evt: Event) {
+			return handler(req, context, {
+				send: server.send.bind(server),
+				close: server.close.bind(server),
+				state: state,
+				// @ts-ignore
+				event: evt
+			});
+		}
+
+		async function closer(evt: Event) {
+			try { await caller(evt) }
+			finally { server.close() }
+		}
+
+		server.accept();
+
+		// NOTE: currently "open" is never called
+		// server.addEventListener('open', caller);
+		server.addEventListener('close', closer);
+		server.addEventListener('message', caller);
+		server.addEventListener('error', closer);
+
+		return new Response(null, {
+			status: 101,
+			statusText: 'Switching Protocols',
+			webSocket: client
+		});
+	};
+}

--- a/packages/worktop/src/ws.d.ts
+++ b/packages/worktop/src/ws.d.ts
@@ -1,54 +1,5 @@
-import type { WebSocket } from 'worktop/cfw';
-import type { Context, Params } from 'worktop';
-import type { Dict, Strict, Promisable } from 'worktop/utils';
-
-declare global {
-	interface ResponseInit {
-		/** @note Cloudflare only */
-		webSocket?: WebSocket;
-	}
-}
-
-export type { WebSocket };
-export type State = Dict<any>;
-
-export interface Socket<S extends State = State> {
-	send: WebSocket['send'];
-	close: WebSocket['close'];
-	state: S; // todo: not happy w/ name
-	event:
-		| { type: 'close' } & CloseEvent
-		| { type: 'message' } & MessageEvent<string>
-		| { type: 'error' } & Event;
-}
-
-export type SocketHandler<
-	C extends Context = Context,
-	P extends Params = Params,
-	S extends State = State,
-> = (
-	request: Request,
-	context: C, // todo: omit
-	socket: Socket<S>
-) => Promisable<void>;
-
 /**
  * Ensure the incoming `Request` can be upgraded to a Websocket connection.
- * @NOTE This is called automatically within the `listen()` method.
+ * @NOTE Returns an error `Response` if the request cannot upgrade.
  */
 export function connect(req: Request): Response | void;
-
-/**
- * Establish a Websocket connection.
- * Attach the `handler` as the 'message' event listener.
- * @NOTE Invokes the `connect()` middleware automatically.
- */
-export function listen<
-	C extends Context = Context,
-	P extends Params = Params,
->(handler: SocketHandler<C, P>): (
-	request: Request,
-	context: Omit<C, 'params'> & {
-		params: Strict<P>;
-	}
-) => Response;

--- a/packages/worktop/src/ws.test.ts
+++ b/packages/worktop/src/ws.test.ts
@@ -71,18 +71,3 @@ connect('should now throw error if valid handshake', () => {
 });
 
 connect.run();
-
-// ---
-
-const listen = suite('listen');
-
-listen('should be a function', () => {
-	assert.type(ws.listen, 'function');
-});
-
-listen('should return a function', () => {
-	let out = ws.listen(() => {});
-	assert.type(out, 'function');
-});
-
-listen.run();

--- a/packages/worktop/src/ws.ts
+++ b/packages/worktop/src/ws.ts
@@ -1,9 +1,5 @@
 import { abort } from './internal/ws';
 
-import type { SocketHandler } from 'worktop/ws';
-import type { Context, Params } from 'worktop';
-import type { Dict } from 'worktop/utils';
-
 // TODO: Might need to only be 400 code?
 // @see https://datatracker.ietf.org/doc/rfc6455/?include_text=1
 // @see https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API/Writing_WebSocket_servers
@@ -18,49 +14,4 @@ export function connect(req: Request) {
 
 	value = req.headers.get('sec-websocket-version');
 	if (value !== '13') return abort(400);
-}
-
-type State = Dict<any>;
-
-export function listen<
-	C extends Context = Context,
-	P extends Params = Params,
-	S extends State = State,
->(handler: SocketHandler<C, P, S>): (req: Request, context: C) => Response {
-	return function (req, context) {
-		let error = connect(req);
-		if (error) return error;
-
-		let { 0: client, 1: server } = new WebSocketPair;
-
-		let state = {} as S;
-		function caller(evt: Event) {
-			return handler(req, context, {
-				send: server.send.bind(server),
-				close: server.close.bind(server),
-				state: state,
-				// @ts-ignore
-				event: evt
-			});
-		}
-
-		async function closer(evt: Event) {
-			try { await caller(evt) }
-			finally { server.close() }
-		}
-
-		server.accept();
-
-		// NOTE: currently "open" is never called
-		// server.addEventListener('open', caller);
-		server.addEventListener('close', closer);
-		server.addEventListener('message', caller);
-		server.addEventListener('error', closer);
-
-		return new Response(null, {
-			status: 101,
-			statusText: 'Switching Protocols',
-			webSocket: client
-		});
-	};
 }

--- a/packages/worktop/types/cfw.durable.ts
+++ b/packages/worktop/types/cfw.durable.ts
@@ -4,8 +4,8 @@ import * as cookies from 'worktop/cookie';
 import * as utils from 'worktop/utils';
 
 import type { Bindings } from 'worktop/cfw';
+import type { WebSocket } from 'worktop/cfw.ws';
 import type { Durable } from 'worktop/cfw.durable';
-import type { WebSocket } from 'worktop/ws';
 import type { KV } from 'worktop/cfw.kv';
 
 interface CustomBindings extends Bindings {

--- a/packages/worktop/types/cfw.ws.ts
+++ b/packages/worktop/types/cfw.ws.ts
@@ -1,4 +1,4 @@
-import * as ws from 'worktop/ws';
+import * as ws from 'worktop/cfw.ws';
 import { compose } from 'worktop';
 
 import type { Router, Context } from 'worktop';


### PR DESCRIPTION
Needs `/deno.ws.ts` module – might be separate PR

---

Related: #133