### PR TITLE
break(cache): generalize `worktop/cache` & add new `worktop/cfw.cache` module

### DIFF
--- a/bin/register.js
+++ b/bin/register.js
@@ -3,6 +3,9 @@ const { transformSync } = require('esbuild');
 
 const loadJS = require.extensions['.js'];
 
+// @ts-ignore - worktop/cfw.cache
+globalThis.caches = { default: {} };
+
 // @ts-ignore - worktop/utils, worktop/crypto
 globalThis.crypto = require('crypto').webcrypto;
 

--- a/bin/register.js
+++ b/bin/register.js
@@ -3,9 +3,6 @@ const { transformSync } = require('esbuild');
 
 const loadJS = require.extensions['.js'];
 
-// @ts-ignore - worktop/cache
-globalThis.caches = { default: {} };
-
 // @ts-ignore - worktop/utils, worktop/crypto
 globalThis.crypto = require('crypto').webcrypto;
 

--- a/examples/workers/kv-todos/index.ts
+++ b/examples/workers/kv-todos/index.ts
@@ -1,6 +1,6 @@
 import { Router } from 'worktop';
-import * as Cache from 'worktop/cache';
 import { start } from 'worktop/cfw';
+import * as Cache from 'worktop/cfw.cache';
 import * as Todos from './routes';
 
 import type { Context } from './types';

--- a/packages/create-worktop/template/src/cfw.esm.js
+++ b/packages/create-worktop/template/src/cfw.esm.js
@@ -1,11 +1,12 @@
 import { HS256 } from 'worktop/jwt';
 import * as CORS from 'worktop/cors';
-import * as Cache from 'worktop/cache';
-import { Router, compose } from 'worktop';
-import { read, write } from 'worktop/cfw.kv';
-import { reply } from 'worktop/response';
 import * as utils from 'worktop/utils';
+import { reply } from 'worktop/response';
+import { Router, compose } from 'worktop';
+
 import { start } from 'worktop/cfw';
+import * as Cache from 'worktop/cfw.cache';
+import { read, write } from 'worktop/cfw.kv';
 
 // Create new Router
 const API = new Router();

--- a/packages/create-worktop/template/src/cfw.esm.ts
+++ b/packages/create-worktop/template/src/cfw.esm.ts
@@ -1,11 +1,12 @@
 import { HS256 } from 'worktop/jwt';
 import * as CORS from 'worktop/cors';
-import * as Cache from 'worktop/cache';
-import { Router, compose } from 'worktop';
-import { read, write } from 'worktop/cfw.kv';
-import { reply } from 'worktop/response';
 import * as utils from 'worktop/utils';
+import { reply } from 'worktop/response';
+import { Router, compose } from 'worktop';
+
 import { start } from 'worktop/cfw';
+import * as Cache from 'worktop/cfw.cache';
+import { read, write } from 'worktop/cfw.kv';
 
 import type { Context } from 'worktop';
 import type { ULID } from 'worktop/utils';

--- a/packages/create-worktop/template/src/cfw.sw.js
+++ b/packages/create-worktop/template/src/cfw.sw.js
@@ -1,11 +1,12 @@
 import { HS256 } from 'worktop/jwt';
 import * as CORS from 'worktop/cors';
-import * as Cache from 'worktop/cache';
-import { Router, compose } from 'worktop';
-import { read, write } from 'worktop/cfw.kv';
-import { reply } from 'worktop/response';
 import * as utils from 'worktop/utils';
+import { reply } from 'worktop/response';
+import { Router, compose } from 'worktop';
+
 import { listen } from 'worktop/cfw';
+import * as Cache from 'worktop/cfw.cache';
+import { read, write } from 'worktop/cfw.kv';
 
 // Create new Router
 const API = new Router();

--- a/packages/create-worktop/template/src/cfw.sw.ts
+++ b/packages/create-worktop/template/src/cfw.sw.ts
@@ -1,11 +1,12 @@
 import { HS256 } from 'worktop/jwt';
 import * as CORS from 'worktop/cors';
-import * as Cache from 'worktop/cache';
-import { Router, compose } from 'worktop';
-import { read, write } from 'worktop/cfw.kv';
-import { reply } from 'worktop/response';
 import * as utils from 'worktop/utils';
+import { reply } from 'worktop/response';
+import { Router, compose } from 'worktop';
+
 import { listen } from 'worktop/cfw';
+import * as Cache from 'worktop/cfw.cache';
+import { read, write } from 'worktop/cfw.kv';
 
 import type { Context } from 'worktop';
 import type { ULID } from 'worktop/utils';

--- a/packages/worktop/package.json
+++ b/packages/worktop/package.json
@@ -20,6 +20,10 @@
       "import": "./cfw/index.mjs",
       "require": "./cfw/index.js"
     },
+    "./cfw.cache": {
+      "import": "./cfw.cache/index.mjs",
+      "require": "./cfw.cache/index.js"
+    },
     "./cfw.durable": {
       "import": "./cfw.durable/index.mjs",
       "require": "./cfw.durable/index.js"
@@ -95,6 +99,7 @@
     "buffer",
     "cache",
     "cfw",
+    "cfw.cache",
     "cfw.durable",
     "cfw.kv",
     "cfw.kv.assets",

--- a/packages/worktop/src/cache.d.ts
+++ b/packages/worktop/src/cache.d.ts
@@ -2,20 +2,46 @@
 
 import type { Context, Params } from 'worktop';
 import type { Strict } from 'worktop/utils';
-import type { Module } from 'worktop/cfw';
-// TODO: add `EventContext` something
 
-export const Cache: Cache;
-export function save(req: Request | string, res: Response, context: Module.Context): Response;
-export function lookup(request: Request | string): Promise<Response | void>;
-export function isCacheable(res: Response): boolean;
+/**
+ * Determine if the Response can be cached.
+ */
+export function isCacheable(
+	response: Response
+): boolean;
 
-export function sync(): <
-	C extends Context = Context,
-	P extends Params = Params,
->(
+/**
+ * Cache a Response for the given request.
+ * @NOTE A `request` string is treated as a `GET` request.
+ */
+export function save(
+	cache: Cache,
+	request: Request | string,
+	response: Response,
+	context: {
+		waitUntil(f: any): void;
+	}
+): Response;
+
+/**
+ * Attempt to retrieve a cached Response for the request.
+ * @NOTE A `request` string is treated as a `GET` request.
+ */
+export function lookup(
+	cache: Cache,
+	request: Request | string
+): Promise<Response | void>;
+
+/**
+ * Return a `Handler` that will `lookup` incoming requests and `save` outgoing Responses.
+ * If a request has a cached Response, it will be returned. Otherwise this method will
+ * wait for a `Response` and assign it to the request for next lookup.
+ */
+export function sync(
+	cache: Cache
+): <C extends Context = Context, P extends Params = Params>(
 	request: Request,
 	context: Omit<C, 'params'> & {
 		params: Strict<P & C['params']>;
 	}
-) => Response | void;
+) => Response|void;

--- a/packages/worktop/src/cfw.cache.d.ts
+++ b/packages/worktop/src/cfw.cache.d.ts
@@ -1,0 +1,44 @@
+/// <reference lib="webworker" />
+
+import type { Context, Params } from 'worktop';
+import type { Strict } from 'worktop/utils';
+
+/**
+ * Determine if the Response can be cached.
+ */
+export function isCacheable(
+	response: Response
+): boolean;
+
+/**
+ * Cache a Response for the given request.
+ * @NOTE A `request` string is treated as a `GET` request.
+ */
+export function save(
+	request: Request | string,
+	response: Response,
+	context: {
+		waitUntil(f: any): void;
+	}
+): Response;
+
+/**
+ * Attempt to retrieve a cached Response for the request.
+ * @NOTE A `request` string is treated as a `GET` request.
+ */
+export function lookup(request: Request | string): Promise<Response | void>;
+
+/**
+ * Return a `Handler` that will `lookup` incoming requests and `save` outgoing Responses.
+ * If a request has a cached Response, it will be returned. Otherwise this method will
+ * wait for a `Response` and assign it to the request for next lookup.
+ */
+export function sync(): <
+	C extends Context = Context,
+	P extends Params = Params,
+>(
+	request: Request,
+	context: Omit<C, 'params'> & {
+		params: Strict<P & C['params']>;
+	}
+) => Response|void;

--- a/packages/worktop/src/cfw.cache.test.ts
+++ b/packages/worktop/src/cfw.cache.test.ts
@@ -1,0 +1,277 @@
+import { suite } from 'uvu';
+import * as assert from 'uvu/assert';
+import * as Cache from './cfw.cache';
+
+const Storage = caches.default as any;
+
+const Mock = (x?: any) => {
+	let args: any[], f = (...y: any[]) => (args=y,Promise.resolve(x));
+	// @ts-ignore
+	return f.args = () => args,f;
+}
+
+// ---
+
+const lookup = suite('lookup');
+
+lookup('should be a function', () => {
+	assert.type(Cache.lookup, 'function');
+});
+
+lookup('should call `Cache.match` with arguments', async () => {
+	Storage.match = Mock();
+	await Cache.lookup(123 as any);
+	assert.equal(Storage.match.args(), [123]);
+});
+
+lookup('should allow custom `request` value :: string', async () => {
+	Storage.match = Mock();
+	await Cache.lookup('/foo/bar');
+	assert.equal(Storage.match.args(), ['/foo/bar']);
+});
+
+lookup('should allow custom `request` value :: Request', async () => {
+	Storage.match = Mock();
+	const request = { foo: 456 } as any;
+
+	await Cache.lookup(request);
+	assert.equal(Storage.match.args(), [request]);
+});
+
+lookup('should treat HEAD as GET', async () => {
+	let args: any[] = [];
+	Storage.match = (...x: any[]) => {
+		args = x;
+		return new Response('hello');
+	}
+
+	let request = new Request('/foobar', { method: 'HEAD' });
+	let res = await Cache.lookup(request);
+
+	assert.instance(res, Response);
+	assert.is.not(res!.body, 'hello');
+	assert.is(res!.body, null); // because HEAD
+
+	assert.is(args.length, 1);
+	assert.instance(args[0], Request);
+	assert.is(args[0].url, '/foobar');
+	assert.is(args[0].method, 'GET');
+});
+
+lookup.run();
+
+// ---
+
+const isCacheable = suite('isCacheable');
+
+isCacheable('should be a function', () => {
+	assert.type(Cache.isCacheable, 'function');
+});
+
+isCacheable('status code :: 200', () => {
+	const res = new Response();
+	assert.is(Cache.isCacheable(res), true);
+});
+
+isCacheable('status code :: 206', () => {
+	const res = new Response(null, { status: 206 });
+	assert.is(Cache.isCacheable(res), false);
+});
+
+isCacheable('status code :: 101', () => {
+	const res = new Response(null, { status: 101 });
+	assert.is(Cache.isCacheable(res), false);
+});
+
+isCacheable('cache-control :: public', () => {
+	const res = new Response();
+	res.headers.set('cache-control', 'public,max-age=0');
+	assert.is(Cache.isCacheable(res), true);
+});
+
+isCacheable('cache-control :: private', () => {
+	const res = new Response();
+	res.headers.set('cache-control', 'private,max-age=0');
+	assert.is(Cache.isCacheable(res), false);
+});
+
+isCacheable('cache-control :: no-store', () => {
+	const res = new Response();
+	res.headers.set('cache-control', 'public,no-store,max-age=0');
+	assert.is(Cache.isCacheable(res), false);
+});
+
+isCacheable('cache-control :: no-cache', () => {
+	const res = new Response();
+	res.headers.set('cache-control', 'public,no-cache');
+	assert.is(Cache.isCacheable(res), false);
+});
+
+isCacheable('vary :: *', () => {
+	const res = new Response();
+	res.headers.set('vary', '*');
+	assert.is(Cache.isCacheable(res), false);
+});
+
+isCacheable('vary :: user-agent', () => {
+	const res = new Response();
+	res.headers.set('vary', 'user-agent');
+	assert.is(Cache.isCacheable(res), true);
+});
+
+isCacheable('vary :: multiple', () => {
+	const res = new Response();
+	res.headers.set('vary', 'accept-encoding, accept-language');
+	assert.is(Cache.isCacheable(res), true);
+});
+
+isCacheable.run();
+
+// ---
+
+const save = suite('save');
+
+save('should be a function', () => {
+	assert.type(Cache.save, 'function');
+});
+
+save('should call `event.waitUntil` and `Cache.put` when Response is cacheable', () => {
+	let waited=0, res = new Response();
+	let request = new Request('/', { method: 'GET' });
+	Storage.put = Mock();
+
+	let output = Cache.save(request, res, {
+		waitUntil() {
+			waited = 1;
+		}
+	});
+
+	// no "set-cookie" -> no reset
+	assert.ok(output === res);
+
+	assert.equal(
+		Storage.put.args(),
+		[request, res]
+	);
+
+	assert.is(waited, 1);
+});
+
+save('should treat custom `request`-string as GET', () => {
+	let waited = 0;
+	let res = new Response;
+	Storage.put = Mock();
+
+	let output = Cache.save('/foo/bar', res, {
+		waitUntil() {
+			waited = 1;
+		}
+	});
+
+	assert.ok(output === res);
+
+	assert.equal(
+		Storage.put.args(),
+		['/foo/bar', res]
+	);
+
+	assert.is(waited, 1);
+});
+
+save('should not save Response if not GET method :: POST', () => {
+	let waited=0, saved=0;
+	const res = new Response();
+	const request = { method: 'POST' } as Request;
+	const event: any = { request, waitUntil: () => waited=1 };
+	Storage.put = () => saved=1;
+
+	const output = Cache.save(request, res, event);
+	assert.ok(output === res);
+
+	assert.is(saved, 0);
+	assert.is(waited, 0);
+});
+
+save('should not save Response if not GET method :: HEAD', () => {
+	let waited=0, saved=0;
+	const res = new Response();
+	const request = { method: 'HEAD' };
+	const event: any = { request, waitUntil: () => waited=1 };
+	Storage.put = () => saved=1;
+
+	const output = Cache.save(event.request, res, event);
+	assert.ok(output === res);
+
+	assert.is(saved, 0);
+	assert.is(waited, 0);
+});
+
+save('should not save Response if not cacheable', () => {
+	let waited=0, saved=0;
+	const res = new Response(null, { status: 206 }); // <~ cacheable=false
+	const request = { method: 'HEAD' };
+	const event: any = { request, waitUntil: () => waited=1 };
+	Storage.put = () => saved=1;
+
+	const output = Cache.save(event.request, res, event);
+	assert.ok(output === res);
+
+	assert.is(saved, 0);
+	assert.is(waited, 0);
+});
+
+save('should mark `private=set-cookie` :: write', () => {
+	Storage.put = Mock();
+
+	let waited = 0;
+	let res = new Response();
+	let request = new Request('/', { method: 'GET' });
+	let event: any = { request, waitUntil: () => waited=1 };
+
+	// set "existing" headers
+	res.headers.set('set-cookie', 'foo=bar');
+	assert.ok(Cache.isCacheable(res));
+
+	let copy = Cache.save(event.request, res, event);
+	assert.is.not(copy, res); // res = res.clone()
+
+	assert.equal(
+		Storage.put.args(),
+		[request, res]
+	);
+
+	assert.is(waited, 1);
+
+	let cc = copy.headers.get('cache-control');
+	assert.is.not(res.headers.get('cache-control'), cc);
+	assert.is(cc, 'private=Set-Cookie');
+});
+
+save('should mark `private=set-cookie` :: append', () => {
+	let waited = 0;
+	let res = new Response();
+	let request = new Request('/', { method: 'GET' });
+	let event: any = { request, waitUntil: () => waited=1 };
+	Storage.put = Mock();
+
+	// set "existing" headers
+	res.headers.set('set-cookie', 'foo=bar');
+	res.headers.set('cache-control', 'public,max-age=0');
+
+	assert.ok(Cache.isCacheable(res));
+	let copy = Cache.save(event.request, res, event);
+	assert.is.not(copy, res); // res = res.clone()
+
+	assert.equal(
+		Storage.put.args(),
+		[request, res]
+	);
+
+	assert.is(waited, 1);
+
+	let cc = copy.headers.get('cache-control');
+	assert.is(cc, 'public,max-age=0, private=Set-Cookie');
+	assert.is.not(res.headers.get('cache-control'), cc);
+});
+
+save.run();

--- a/packages/worktop/src/cfw.cache.ts
+++ b/packages/worktop/src/cfw.cache.ts
@@ -1,0 +1,9 @@
+import * as Cache from 'worktop/cache';
+
+const CFW_CACHE = /*#__PURE__*/ caches.default;
+
+export const save = /*#__PURE__*/ Cache.save.bind(0, CFW_CACHE);
+export const lookup = /*#__PURE__*/ Cache.lookup.bind(0, CFW_CACHE);
+export const sync = /*#__PURE__*/ Cache.sync.bind(0, CFW_CACHE);
+
+export { isCacheable } from 'worktop/cache';

--- a/packages/worktop/types/cache.ts
+++ b/packages/worktop/types/cache.ts
@@ -7,49 +7,50 @@ declare const event: FetchEvent;
 declare const request: Request;
 declare const response: Response;
 declare const context: Module.Context;
+declare const cache: Cache;
 declare const API: Router;
 
 /**
  * SAVE
  */
 
-Cache.save(event.request, response, context);
-Cache.save('/foo/bar', response, context);
-Cache.save(request, response, context);
+Cache.save(cache, event.request, response, context);
+Cache.save(cache, '/foo/bar', response, context);
+Cache.save(cache, request, response, context);
 
 // event has `waitUntil` on it
-Cache.save(request, response, event);
+Cache.save(cache, request, response, event);
 
 // @ts-expect-error
-Cache.save(event, response, context);
+Cache.save(cache, event, response, context);
 
 // @ts-expect-error
-Cache.save(123, response, context);
+Cache.save(cache, 123, response, context);
 
 // @ts-expect-error
-Cache.save(request, 123, context);
+Cache.save(cache, request, 123, context);
 
 assert<Response>(
-	Cache.save(request, response, event)
+	Cache.save(cache, request, response, event)
 );
 
 /**
  * SAVE
  */
 
-Cache.lookup(request);
-Cache.lookup('/foo/bar');
-Cache.lookup(event.request);
+Cache.lookup(cache, request);
+Cache.lookup(cache, '/foo/bar');
+Cache.lookup(cache, event.request);
 
 // @ts-expect-error
-Cache.lookup(event);
+Cache.lookup(cache, event);
 
 assert<Promise<Response|void>>(
-	Cache.lookup(request)
+	Cache.lookup(cache, request)
 );
 
 assert<Response | void>(
-	await Cache.lookup(request)
+	await Cache.lookup(cache, request)
 );
 
 /**
@@ -72,8 +73,14 @@ Cache.isCacheable(request);
  * sync
  */
 
+// @ts-expect-error
+Cache.sync();
+
+// @ts-expect-error
+Cache.sync(request);
+
 assert<Handler>(
-	Cache.sync()
+	Cache.sync(cache)
 );
 
 
@@ -83,10 +90,11 @@ assert<Handler>(
 
 // @ts-expect-error
 API.prepare = Cache.sync;
-API.prepare = Cache.sync();
+
+API.prepare = Cache.sync(cache);
 
 API.prepare = compose(
-	Cache.sync(),
+	Cache.sync(cache),
 	async (req, res) => {
 		return new Response
 	}
@@ -98,9 +106,9 @@ API.prepare = compose(
 
 addEventListener('fetch', event => {
 	event.respondWith(
-		Cache.lookup(event.request).then(prev => {
+		Cache.lookup(cache, event.request).then(prev => {
 			return prev || Promise.resolve(response).then(res => {
-				return Cache.save(event.request, res, event);
+				return Cache.save(cache, event.request, res, event);
 			});
 		})
 	);

--- a/packages/worktop/types/cfw.cache.ts
+++ b/packages/worktop/types/cfw.cache.ts
@@ -1,0 +1,114 @@
+import { compose } from 'worktop';
+import type { Module } from 'worktop/cfw';
+import * as Cache from 'worktop/cfw.cache';
+import type { Router, Handler } from 'worktop';
+
+declare const event: FetchEvent;
+declare const request: Request;
+declare const response: Response;
+declare const context: Module.Context;
+declare const API: Router;
+
+/**
+ * SAVE
+ */
+
+Cache.save(event.request, response, context);
+Cache.save('/foo/bar', response, context);
+Cache.save(request, response, context);
+
+// event has `waitUntil` on it
+Cache.save(request, response, event);
+
+// @ts-expect-error
+Cache.save(event, response, context);
+
+// @ts-expect-error
+Cache.save(123, response, context);
+
+// @ts-expect-error
+Cache.save(request, 123, context);
+
+assert<Response>(
+	Cache.save(request, response, event)
+);
+
+/**
+ * SAVE
+ */
+
+Cache.lookup(request);
+Cache.lookup('/foo/bar');
+Cache.lookup(event.request);
+
+// @ts-expect-error
+Cache.lookup(event);
+
+assert<Promise<Response|void>>(
+	Cache.lookup(request)
+);
+
+assert<Response | void>(
+	await Cache.lookup(request)
+);
+
+/**
+ * isCacheable
+ */
+
+Cache.isCacheable(response);
+
+assert<boolean>(
+	Cache.isCacheable(response)
+);
+
+// @ts-expect-error
+Cache.isCacheable(123);
+
+// @ts-expect-error
+Cache.isCacheable(request);
+
+/**
+ * sync
+ */
+
+// @ts-expect-error
+Cache.sync({} as Cache);
+
+// @ts-expect-error
+Cache.sync(request);
+
+assert<Handler>(
+	Cache.sync()
+);
+
+
+/**
+ * ROUTER
+ */
+
+// @ts-expect-error
+API.prepare = Cache.sync;
+
+API.prepare = Cache.sync();
+
+API.prepare = compose(
+	Cache.sync(),
+	async (req, res) => {
+		return new Response
+	}
+);
+
+/**
+ * Service Worker
+ */
+
+addEventListener('fetch', event => {
+	event.respondWith(
+		Cache.lookup(event.request).then(prev => {
+			return prev || Promise.resolve(response).then(res => {
+				return Cache.save(event.request, res, event);
+			});
+		})
+	);
+});

--- a/packages/worktop/types/demo.ts
+++ b/packages/worktop/types/demo.ts
@@ -1,11 +1,12 @@
 import { HS256 } from 'worktop/jwt';
 import * as CORS from 'worktop/cors';
-import * as Cache from 'worktop/cache';
-import { read, write } from 'worktop/cfw.kv';
-import { Router, compose } from 'worktop';
-import { reply } from 'worktop/response';
 import * as utils from 'worktop/utils';
+import { reply } from 'worktop/response';
+import { Router, compose } from 'worktop';
+
 import { start } from 'worktop/cfw';
+import * as Cache from 'worktop/cfw.cache';
+import { read, write } from 'worktop/cfw.kv';
 
 import type { Context } from 'worktop';
 import type { ULID } from 'worktop/utils';

--- a/packages/worktop/types/init.ts
+++ b/packages/worktop/types/init.ts
@@ -7,6 +7,7 @@ import type { Context, Router } from 'worktop';
 import type { Bindings, CronEvent, Module } from 'worktop/cfw';
 
 declare const API: Router;
+declare const CACHE: Cache;
 declare const CUSTOM: Router<MyContext>;
 
 interface MyBindings extends Bindings {
@@ -109,9 +110,9 @@ addEventListener('fetch', API.run);
 
 addEventListener('fetch', event => {
 	event.respondWith(
-		Cache.lookup(event.request).then(prev => {
+		Cache.lookup(CACHE, event.request).then(prev => {
 			return prev || API.run(event.request, event).then(res => {
-				return Cache.save(event.request, res, event);
+				return Cache.save(CACHE, event.request, res, event);
 			})
 		})
 	)

--- a/packages/worktop/types/router.strict.ts
+++ b/packages/worktop/types/router.strict.ts
@@ -1,6 +1,6 @@
-import * as Cache from 'worktop/cache';
 import { Router, compose } from 'worktop';
-import * as modules from 'worktop/cfw';
+import * as Cache from 'worktop/cfw.cache';
+import * as cfw from 'worktop/cfw';
 import * as sw from 'worktop/sw';
 
 import type { Context } from 'worktop';
@@ -50,9 +50,10 @@ API.add('GET', '/:foo/:bar?', async (req, context) => {
 /**
  * init: service worker
  */
+cfw.listen(API.run);
 sw.start(API.run);
 
 /**
  * init: module worker
  */
-export default modules.start(API.run);
+export default cfw.start(API.run);

--- a/readme.md
+++ b/readme.md
@@ -71,7 +71,7 @@ const API = new Router<Bindings>();
 // Any `prepare` logic runs 1st for every request, before routing
 // ~> use `Cache` for request-matching, when permitted
 // ~> store Response in `Cache`, when permitted
-API.prepare = Cache.sync();
+API.prepare = Cache.sync(caches.default);
 
 API.add('GET', '/messages/:id', async (req, context) => {
   // Pre-parsed `context.params` object

--- a/readme.md
+++ b/readme.md
@@ -45,10 +45,12 @@ $ npm install --save worktop
 ```ts
 import { Router } from 'worktop';
 import * as utils from 'worktop/utils';
-import { read, write } from 'worktop/cfw.kv';
 import { reply } from 'worktop/response';
-import * as Cache from 'worktop/cache';
+
+// Cloudflare-specific Submodules
 import { start } from 'worktop/cfw';
+import * as Cache from 'worktop/cfw.cache';
+import { read, write } from 'worktop/cfw.kv';
 
 import type { KV } from 'worktop/cfw.kv';
 import type { Context } from 'worktop';
@@ -71,7 +73,7 @@ const API = new Router<Bindings>();
 // Any `prepare` logic runs 1st for every request, before routing
 // ~> use `Cache` for request-matching, when permitted
 // ~> store Response in `Cache`, when permitted
-API.prepare = Cache.sync(caches.default);
+API.prepare = Cache.sync();
 
 API.add('GET', '/messages/:id', async (req, context) => {
   // Pre-parsed `context.params` object


### PR DESCRIPTION
Makes the core `worktop/cache` module generic & able to function on any/all platforms. This is done by adding a `cache` parameter to the `lookup | save | sync` methods, which is a breaking change.

Added a `worktop/cfw.cache` module, which is **exactly** the same as `worktop/cache` except that it uses `caches.default` for the `cache` parameter. This means that it has the exact same API/usage as the `worktop/cache` that existed **before** this PR.

In other words:

```diff
// For Cloudflare users:
-- import * as Cache from 'worktop/cache';
++ import * as Cache from 'worktop/cfw.cache';
// ^^ Exactly the same usage
```

If you want to continue using `worktop/cache`, then do this:

```diff
import * as Cache from 'worktop/cache';

-- let res = await Cache.lookup(request);
++ let res = await Cache.lookup(caches.default, request);
```