### PR TITLE
feat(cfw.durable): integrate Cache API with `Database` operations

### DIFF
--- a/packages/worktop/src/cfw.durable.d.ts
+++ b/packages/worktop/src/cfw.durable.d.ts
@@ -90,17 +90,25 @@ export abstract class Actor {
 
 export const DataGroup: Durable.Object;
 
+// @private
+type CacheOptions = {
+	/** seconds */
+	cacheTtl?: number;
+	/** custom cache identifier; ideal for multi-key scenarios */
+	cacheKey?: string;
+};
+
 export class Database {
 	constructor(namespace: Durable.Namespace);
 
-	get<T>(shard: string, key: string, options?: Durable.Storage.Options.Get): Promise<T|void>;
-	get<T>(shard: string, keys: string[], options?: Durable.Storage.Options.Get): Promise<Map<string, T>>;
+	get<T>(shard: string, key: string, options?: Durable.Storage.Options.Get & CacheOptions): Promise<T|void>;
+	get<T>(shard: string, keys: string[], options?: Durable.Storage.Options.Get & CacheOptions): Promise<Map<string, T>>;
 
-	put<T>(shard: string, entries: Dict<T>, options?: { overwrite?: boolean } & Durable.Storage.Options.Put): Promise<boolean>;
-	put<T>(shard: string, key: string, value: T, options?: { overwrite?: boolean } & Durable.Storage.Options.Put): Promise<boolean>;
+	put<T>(shard: string, entries: Dict<T>, options?: { overwrite?: boolean } & Durable.Storage.Options.Put & CacheOptions): Promise<boolean>;
+	put<T>(shard: string, key: string, value: T, options?: { overwrite?: boolean } & Durable.Storage.Options.Put & CacheOptions): Promise<boolean>;
 
-	delete(shard: string, key: string, options?: Durable.Storage.Options.Put): Promise<boolean>;
-	delete(shard: string, key: string[], options?: Durable.Storage.Options.Put): Promise<number>;
+	delete(shard: string, key: string, options?: Durable.Storage.Options.Put & CacheOptions): Promise<boolean>;
+	delete(shard: string, key: string[], options?: Durable.Storage.Options.Put & CacheOptions): Promise<number>;
 
 	list<T>(shard: string, options?: Durable.Storage.Options.List): Promise<Map<string, T>>;
 }

--- a/packages/worktop/types/cfw.durable.ts
+++ b/packages/worktop/types/cfw.durable.ts
@@ -164,6 +164,26 @@ await database.get('projects', '123', {
 	noCache: true,
 });
 
+await database.get('projects', '123', {
+	noCache: false,
+	cacheTtl: 86400, // 1d
+});
+
+assert<Map<string, number>>(
+	await database.get<number>('projects', ['foo', 'bar'], {
+		cacheKey: 'foobar',
+		cacheTtl: 86400, // 1d
+	})
+);
+
+assert<Map<string, number>>(
+	// @ts-expect-error - map value-type mismatch
+	await database.get<string>('projects', ['foo', 'bar'], {
+		cacheKey: 'foobar',
+		cacheTtl: 86400, // 1d
+	})
+);
+
 assert<unknown>(
 	await database.get('projects', 'key')
 );
@@ -194,6 +214,11 @@ await database.put<number>('projects', 'key', 123, {
 	noCache: true,
 });
 
+await database.put<number>('projects', 'key', 123, {
+	cacheTtl: 86400, // 1d
+	noCache: false,
+});
+
 assert<string>(
 	// @ts-expect-error - return type
 	await database.put('projects', 'key', 123)
@@ -214,6 +239,15 @@ await database.put('projects', {
 }, {
 	overwrite: true,
 	allowUnconfirmed: true,
+});
+
+await database.put('projects', {
+	foo: 123,
+	bar: 'value',
+}, {
+	cacheTtl: 86400, // 1d
+	overwrite: false,
+	cacheKey: 'foobar',
 });
 
 // @ts-expect-error
@@ -254,6 +288,11 @@ await database.delete('projects', 'foobar', {
 	allowUnconfirmed: true
 });
 
+await database.delete('projects', 'foobar', {
+	cacheKey: 'howdy',
+	cacheTtl: 123, // unused but present
+});
+
 assert<boolean>(
 	// @ts-expect-error - return type
 	await database.delete('projects', ['key1', 'key2'])
@@ -265,6 +304,13 @@ assert<boolean>(
 
 assert<number>(
 	await database.delete('projects', ['key1', 'key2'])
+);
+
+assert<number>(
+	await database.delete('projects', ['key1', 'key2'], {
+		cacheKey: 'mykeys',
+		cacheTtl: 0, // unused but can be present
+	})
 );
 
 assert<Map<string, unknown>>(

--- a/packages/worktop/types/router.strict.ts
+++ b/packages/worktop/types/router.strict.ts
@@ -68,7 +68,19 @@ API.add('GET', '/:foo/:bar?', async (req, context) => {
 
 	let { database } = context;
 	let { foo, bar='default' } = context.params;
-	let item = await database.get<string>('foo:' + foo, bar);
+
+	let shard = `foo:${foo}`;
+
+	let success = await database.put<string>(shard, bar, 'hello', {
+		overwrite: true,
+		cacheTtl: 3600 // 1h
+	});
+
+	let item = await database.get<string>(shard, bar, {
+		cacheTtl: 3600, // 1h
+		noCache: false,
+	});
+
 	assert<string|void>(item);
 });
 


### PR DESCRIPTION
Places the Cache API in front of all Durable Object storage operations when using the (new) `Database` class via #148 /cc @eidam

The Cache is operated from the Worker's PoV, which means that copies of the key-values will only appear and be present where the requests are originating from. This is nice because the Durable Objects themselves will move / be placed closest to where they are needed & being requested from.

Writes to the DO storage will always be cached when `options.cacheTtl` is used and `options.noCache` **is not used**. The cached document will live for the `cacheTtl` duration in seconds.

When reading from the DB, if `options.cacheTtl` is used and `options.noCache` **is not used**, the DB attempts to use the Cache API first. Should there be a Cache MISS, then the raw query operation is performed and then written back to Cache using the `cacheTtl` value (in seconds).

When deleting keys from the DB, the operation will forward to the Cache layer **only if** `options.noCache` **is not used**.

---

All Cached-based methods support a `cacheKey` option, which is how you may customize the key used for Cache writes/reads. This is ideal for reads and writes involving multiple keys. For example:

```ts
await database.put('users', {
  lukeed: 'Luke',
  eidam: 'Adam'
}, {
  cacheKey: 'creators',
  cacheTtl: 86400, // 1d
});
```

The `Database` **will not** create 2 separate Cache documents (due to the [Cache operation limits](https://developers.cloudflare.com/workers/platform/limits/#cache-api-limits)). Instead, the Cache will only be invoked for multi-key operation if a `cacheKey` is supplied.

> Cache keys are prefixed by the `shard` value, allowing you to reuse the same `options.cacheKey` across multiple shards/data-types within your application. In the above example, `"users"` is the shard value, meaning that `"users~creators"` is the true cache key value.

With this example, the `lukeed` and `eidam` pairing are available under the singular `"users~creators"` cache key. This means that when requesting the data subset for `lukeed` and `eidam` again in the next 1 day (`86400` seconds), you may supply the `"users~creators"` cache key:

```ts
await database.get('users', ['lukeed', 'eidam'], {
  cacheKey: 'creators',
  cacheTtl: 86400, // 1d
});
//=> looks for "users~creators" in Cache
// => if MISS, runs the raw query
// => then writes the response to Cache using the "users~creators" key

await database.get('users', ['lukeed', 'eidam', 'foobar'], {
  cacheKey: 'creators',
  cacheTtl: 86400, // 1d
});
//=> same as above
//=> meaning that "foobar" is ignored
```