### PR TITLE
Fix a documentation error and move "res" to "context"

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -61,24 +61,24 @@ interface Message {
 const API = new Router();
 
 
-API.add('GET', '/messages/:id', async (req, res) => {
+API.add('GET', '/messages/:id', async (req, context) => {
   // Pre-parsed `req.params` object
-  const key = `messages::${req.params.id}`;
+  const key = `messages::${context.params.id}`;
 
   // Assumes JSON (can override)
   const message = await read<Message>(DATA, key);
 
   // Alter response headers directly
-  res.setHeader('Cache-Control', 'public, max-age=60');
+  context.setHeader('Cache-Control', 'public, max-age=60');
 
-  // Smart `res.send()` helper
+  // Smart `context.send()` helper
   // ~> automatically stringifies JSON objects
   // ~> auto-sets `Content-Type` & `Content-Length` headers
-  res.send(200, message);
+  context.send(200, message);
 });
 
 
-API.add('POST', '/messages', async (req, res) => {
+API.add('POST', '/messages', async (req, context) => {
   try {
     // Smart `req.body` helper
     // ~> parses JSON header as JSON


### PR DESCRIPTION
The most important change in this pr is changing `req.params.id` to `context.params.id` on line 66, as whether or not the context part of this pr is merged that is still an issue

I also moved `res` to `context`, I am not 100% sure which one you prefer so I can revert that change, I just been using it myself and I saw you use it on the stream you did with Kev and I think it makes sense