### PR TITLE
Update Cloudflare Worker types

### DIFF
--- a/packages/worktop/src/cfw.d.ts
+++ b/packages/worktop/src/cfw.d.ts
@@ -82,13 +82,29 @@ export interface CronEvent {
 /**
  * Cloudflare Request Metadata/Properties
  * @see https://developers.cloudflare.com/workers/runtime-apis/request#incomingrequestcfproperties
+ * @see https://github.com/cloudflare/workers-types/blob/master/overrides/cf.d.ts (IncomingRequestCfProperties)
  */
 export interface IncomingCloudflareProperties {
 	/**
 	 * The ASN of the incoming request
-	 * @example "395747"
+	 * @example 395747
 	 **/
-	asn: string;
+	asn: number;
+	/**
+	 * The organisation which owns the ASN of the incoming request.
+	 * (e.g. Google Cloud)
+	 */
+	asOrganization: string;
+	botManagement?: {
+		score: number;
+		staticResource: boolean;
+		verifiedBot: boolean;
+	};
+	/**
+	 * Round-trip time (in ms) from client to the colo data center that the request hit
+	 */
+	clientTcpRtt: number;
+	clientTrustScore?: number;
 	/**
 	 * The three-letter `IATA` airport code of the data center that the request hit
 	 * @example "DFW"

--- a/packages/worktop/src/cfw.d.ts
+++ b/packages/worktop/src/cfw.d.ts
@@ -82,7 +82,7 @@ export interface CronEvent {
 /**
  * Cloudflare Request Metadata/Properties
  * @see https://developers.cloudflare.com/workers/runtime-apis/request#incomingrequestcfproperties
- * @see https://github.com/cloudflare/workers-types/blob/master/overrides/cf.d.ts (IncomingRequestCfProperties)
+ * @see https://github.com/cloudflare/workers-types/blob/master/overrides/cf.d.ts
  */
 export interface IncomingCloudflareProperties {
 	/**
@@ -92,7 +92,7 @@ export interface IncomingCloudflareProperties {
 	asn: number;
 	/**
 	 * The organisation which owns the ASN of the incoming request.
-	 * (e.g. Google Cloud)
+	 * @example "Google Cloud"
 	 */
 	asOrganization: string;
 	botManagement?: {


### PR DESCRIPTION
The upstream NPM library is [@cloudflare/workers-types](https://github.com/cloudflare/workers-types/blob/master/overrides/cf.d.ts), which Cloudflare updates automatically from their API changes.

This PR add several new properties, and changes `req.cf.asn` to be a `number` because of what's in the CF spec.

Relates to #156 