### PR TITLE
feat(kv): add `Entity` class

### DIFF
--- a/packages/worktop/src/cfw.kv.d.ts
+++ b/packages/worktop/src/cfw.kv.d.ts
@@ -1,4 +1,4 @@
-import type { Dict } from 'worktop/utils';
+import type { Dict, Promisable } from 'worktop/utils';
 
 export namespace KV {
 	type Metadata = Dict<any>;
@@ -136,6 +136,10 @@ export declare class Entity {
 
 	constructor(binding: KV.Namespace);
 
+	onread?(key: string, value: unknown): Promisable<void>;
+	onwrite?(key: string, value: unknown): Promisable<void>;
+	ondelete?(key: string, value: unknown): Promisable<void>;
+
 	list(options?: KV.Options.List): Promise<string[]>;
 
 	get(key: string, type: 'text'): Promise<string|null>;
@@ -143,5 +147,6 @@ export declare class Entity {
 	get(key: string, type: 'arrayBuffer'): Promise<ArrayBuffer|null>;
 
 	put<T>(key: string, value: T|null): Promise<boolean>;
-	delete(key: string): Promise<boolean>;
+
+	delete(key: string, format?: 'text' | 'json' | 'arrayBuffer'): Promise<boolean>;
 }

--- a/packages/worktop/src/cfw.kv.d.ts
+++ b/packages/worktop/src/cfw.kv.d.ts
@@ -106,3 +106,42 @@ export function until<X extends string>(
 	toMake: () => X,
 	toSearch: (val: X) => Promise<unknown | false>
 ): Promise<X>;
+
+export declare class Entity {
+	/**
+	 * The KV Namespace for this entity.
+	 */
+	readonly ns: KV.Namespace;
+
+	/**
+	 * Cache.Entity operations
+	 */
+	readonly cache: {
+		get(key: string): Promise<Response|void>;
+		put<T>(key: string, value: T|null, ttl: number): Promise<boolean>;
+		delete(key: string): Promise<boolean>;
+	};
+
+	/**
+	 * cache ttl (seconds)
+	 * @default 0
+	 */
+	ttl?: number;
+
+	/**
+	 * key prefix
+	 * @default ""
+	 */
+	prefix?: string;
+
+	constructor(binding: KV.Namespace);
+
+	list(options?: KV.Options.List): Promise<string[]>;
+
+	get(key: string, type: 'text'): Promise<string|null>;
+	get<T=unknown>(key: string, type?: 'json'): Promise<T|null>;
+	get(key: string, type: 'arrayBuffer'): Promise<ArrayBuffer|null>;
+
+	put<T>(key: string, value: T|null): Promise<boolean>;
+	delete(key: string): Promise<boolean>;
+}

--- a/packages/worktop/src/cfw.kv.test.ts
+++ b/packages/worktop/src/cfw.kv.test.ts
@@ -339,3 +339,51 @@ until('should loop until first `nullish` value', async () => {
 });
 
 until.run();
+
+// ---
+
+const Entity = suite('Entity');
+
+Entity('should be a function', () => {
+	assert.type(KV.Entity, 'function');
+});
+
+Entity('should return `Entity` interface', () => {
+	let binding = Namespace();
+	let thing = new KV.Entity(binding);
+
+	assert.type(thing.get, 'function');
+	assert.type(thing.list, 'function');
+	assert.type(thing.delete, 'function');
+	assert.type(thing.put, 'function');
+
+	assert.type(thing.cache, 'object');
+	assert.type(thing.cache.get, 'function');
+	assert.type(thing.cache.delete, 'function');
+	assert.type(thing.cache.put, 'function');
+
+	assert.type(thing.ttl, 'number');
+	assert.is(thing.ns, binding);
+});
+
+Entity('should include property defaults', () => {
+	let binding = Namespace();
+	let thing = new KV.Entity(binding);
+	assert.is(thing.prefix, '');
+	assert.is(thing.ttl, 0);
+});
+
+Entity('should allow class extension', () => {
+	class User extends KV.Entity {
+		ttl = 3600;
+		prefix = 'user';
+	}
+
+	let binding = Namespace();
+	let thing = new User(binding);
+
+	assert.is(thing.prefix, 'user');
+	assert.is(thing.ttl, 3600);
+});
+
+Entity.run();

--- a/packages/worktop/src/internal/cfw.cache.ts
+++ b/packages/worktop/src/internal/cfw.cache.ts
@@ -1,0 +1,32 @@
+import type { KV } from 'worktop/cfw.kv';
+
+export function normalize(value: unknown): KV.Value {
+	return (
+		typeof value === 'string'
+		|| value instanceof ArrayBuffer
+		|| value instanceof ReadableStream
+	) ? value : JSON.stringify(value);
+}
+
+export class Entity {
+	get(key: string): Promise<Response|void> {
+		return caches.default.match(key);
+	}
+
+	put<T>(key: string, value: T|null, ttl: number): Promise<boolean> {
+		if (!ttl) return Promise.resolve(true);
+
+		let headers = { 'cache-control': `public,max-age=${ttl}` };
+		let body = value == null ? null : normalize(value);
+		let res = new Response(body, { headers });
+
+		return caches.default.put(key, res).then(
+			() => true,
+			() => false
+		);
+	}
+
+	delete(key: string): Promise<boolean> {
+		return caches.default.delete(key);
+	}
+}

--- a/packages/worktop/types/cfw.kv.ts
+++ b/packages/worktop/types/cfw.kv.ts
@@ -1,4 +1,4 @@
-import { Database, list, paginate, until } from 'worktop/cfw.kv';
+import { Database, Entity, list, paginate, until } from 'worktop/cfw.kv';
 import type { KV } from 'worktop/cfw.kv';
 
 /**
@@ -137,3 +137,112 @@ async function storage() {
 	let keys = await paginate(APPS, { page: 2, limit: 12, prefix: 'hello' });
 	assert<string>(keys[0]);
 }
+
+/**
+ * Entity
+ */
+
+let apps = new Entity(APPS);
+
+assert<unknown>(
+	await apps.get('abc123')
+);
+
+assert<IApp|null>(
+	await apps.get<IApp>('abc123')
+);
+
+assert<IApp|null>(
+	await apps.get<IApp>('abc123', 'json')
+);
+
+assert<string|null>(
+	await apps.get('abc123', 'text')
+);
+
+assert<ArrayBuffer|null>(
+	await apps.get('abc123', 'arrayBuffer')
+);
+
+// @ts-expect-error - T w/ "text"
+await apps.get<number>('abc123', 'text');
+
+// @ts-expect-error - T w/ "arrayBuffer"
+await apps.get<number>('abc123', 'arrayBuffer');
+
+assert<boolean>(
+	await apps.put('abc123', null)
+);
+
+assert<boolean>(
+	await apps.put('abc123', 'foobar')
+);
+
+assert<boolean>(
+	await apps.put<IApp>('abc123', {
+		uid: toUID(),
+		name: 'foobar'
+	})
+);
+
+assert<boolean>(
+	await apps.put('abc123', new ArrayBuffer(1))
+);
+
+assert<boolean>(
+	await apps.delete('abc123')
+);
+
+assert<number>(apps.ttl!);
+assert<string>(apps.prefix!);
+
+// ---
+
+class User extends Entity {
+	ttl = 3600; // 1hr
+	prefix = 'user';
+}
+
+declare let ns: KV.Namespace;
+let users = new User(ns);
+
+assert<unknown>(
+	await users.get('abc123')
+);
+
+assert<string|null>(
+	await users.get('abc123', 'text')
+);
+
+assert<ArrayBuffer|null>(
+	await users.get('abc123', 'arrayBuffer')
+);
+
+// @ts-expect-error - T w/ "text"
+await users.get<number>('abc123', 'text');
+
+// @ts-expect-error - T w/ "arrayBuffer"
+await users.get<number>('abc123', 'arrayBuffer');
+
+assert<boolean>(
+	await users.put('abc123', null)
+);
+
+assert<boolean>(
+	await users.put('abc123', 'foobar')
+);
+
+assert<boolean>(
+	await users.put<IApp>('abc123', {
+		uid: toUID(),
+		name: 'foobar'
+	})
+);
+
+assert<boolean>(
+	await users.put('abc123', new ArrayBuffer(1))
+);
+
+assert<boolean>(
+	await users.delete('abc123')
+);

--- a/packages/worktop/types/cfw.kv.ts
+++ b/packages/worktop/types/cfw.kv.ts
@@ -201,6 +201,10 @@ assert<string>(apps.prefix!);
 class User extends Entity {
 	ttl = 3600; // 1hr
 	prefix = 'user';
+
+	async onread(key: string, value: IApp) {
+		// do something with the value
+	}
 }
 
 declare let ns: KV.Namespace;


### PR DESCRIPTION
Adds an `Entity` class that is
1.  Module Worker friendly
2. easier to author & approach data in KV as ORM-like models

---

> **NOTE:** There will be a matching `Entity` class exported from the `worktop/cfw.durable` module too, but not at this time as it requires slightly more work. The work from #148 and #149 will be migrated into that class & API.

/cc @eidam