### PR TITLE
break(cfw.kv): only allow JSON data for `Entity` instances

### DIFF
--- a/packages/worktop/src/cfw.kv.d.ts
+++ b/packages/worktop/src/cfw.kv.d.ts
@@ -118,7 +118,7 @@ export declare class Entity<Data=unknown> {
 	 */
 	readonly cache: {
 		get(key: string): Promise<Response|void>;
-		put<T=Data>(key: string, value: T|null, ttl: number): Promise<boolean>;
+		put(key: string, value: Data|null, ttl: number): Promise<boolean>;
 		delete(key: string): Promise<boolean>;
 	};
 
@@ -136,17 +136,12 @@ export declare class Entity<Data=unknown> {
 
 	constructor(binding: KV.Namespace);
 
-	onread?(key: string, value: Data): Promisable<void>;
-	onwrite?(key: string, value: Data): Promisable<void>;
-	ondelete?(key: string, value: Data): Promisable<void>;
+	onread?(key: string, value: Data|null): Promisable<void>;
+	onwrite?(key: string, value: Data|null): Promisable<void>;
+	ondelete?(key: string, value: Data|null): Promisable<void>;
 
+	get(key: string): Promise<Data|null>;
 	list(options?: KV.Options.List): Promise<string[]>;
-
-	get(key: string, type: 'text'): Promise<string|null>;
-	get<T=Data>(key: string, type?: 'json'): Promise<T|null>;
-	get(key: string, type: 'arrayBuffer'): Promise<ArrayBuffer|null>;
-
-	put<T=Data>(key: string, value: T|null): Promise<boolean>;
-
-	delete(key: string, format?: 'text' | 'json' | 'arrayBuffer'): Promise<boolean>;
+	put(key: string, value: Data|null): Promise<boolean>;
+	delete(key: string): Promise<boolean>;
 }

--- a/packages/worktop/types/cfw.kv.ts
+++ b/packages/worktop/types/cfw.kv.ts
@@ -149,43 +149,42 @@ assert<unknown>(
 );
 
 assert<IApp|null>(
-	await apps.get<IApp>('abc123')
+	await apps.get('abc123') as IApp
 );
 
-assert<IApp|null>(
-	await apps.get<IApp>('abc123', 'json')
+assert<string>(
+	// @ts-expect-error - cannot be string w/o override
+	await apps.get('abc123')
 );
 
-assert<string|null>(
-	await apps.get('abc123', 'text')
-);
+// @ts-expect-error - no type args
+await apps.get<IApp>('abc123')
 
-assert<ArrayBuffer|null>(
-	await apps.get('abc123', 'arrayBuffer')
-);
+// @ts-expect-error - no type arg
+await apps.get<number>('abc123');
 
-// @ts-expect-error - T w/ "text"
-await apps.get<number>('abc123', 'text');
-
-// @ts-expect-error - T w/ "arrayBuffer"
-await apps.get<number>('abc123', 'arrayBuffer');
+// @ts-expect-error - no type arg
+await apps.get<number>('abc123');
 
 assert<boolean>(
 	await apps.put('abc123', null)
 );
 
 assert<boolean>(
+	// unknown allows anything
 	await apps.put('abc123', 'foobar')
 );
 
 assert<boolean>(
-	await apps.put<IApp>('abc123', {
+	// unknown allows anything
+	await apps.put('abc123', {
 		uid: toUID(),
 		name: 'foobar'
 	})
 );
 
 assert<boolean>(
+	// unknown allows anything
 	await apps.put('abc123', new ArrayBuffer(1))
 );
 
@@ -198,7 +197,7 @@ assert<string>(apps.prefix!);
 
 // ---
 
-class User extends Entity {
+class User extends Entity<IApp> {
 	ttl = 3600; // 1hr
 	prefix = 'user';
 
@@ -210,99 +209,43 @@ class User extends Entity {
 declare let ns: KV.Namespace;
 let users = new User(ns);
 
-assert<unknown>(
+assert<IApp|null>(
 	await users.get('abc123')
 );
 
-assert<string|null>(
-	await users.get('abc123', 'text')
+assert<string>(
+	// @ts-expect-error - should be IApp
+	await users.get('abc123')
 );
 
-assert<ArrayBuffer|null>(
-	await users.get('abc123', 'arrayBuffer')
-);
-
-// @ts-expect-error - T w/ "text"
-await users.get<number>('abc123', 'text');
-
-// @ts-expect-error - T w/ "arrayBuffer"
-await users.get<number>('abc123', 'arrayBuffer');
+// @ts-expect-error - no format arg
+await users.get('abc123', 'text');
+// @ts-expect-error - no format arg
+await users.get('abc123', 'arrayBuffer');
+// @ts-expect-error - no format arg
+await users.get('abc123', 'json');
 
 assert<boolean>(
 	await users.put('abc123', null)
 );
 
-assert<boolean>(
-	await users.put('abc123', 'foobar')
-);
+// @ts-expect-error - is not IApp
+await users.put('abc123', 123456789);
+// @ts-expect-error - is not IApp data
+await users.put('abc123', new ArrayBuffer(1));
+// @ts-expect-error - is not IApp
+await users.put('abc123', 'foobar');
 
 assert<boolean>(
-	await users.put<IApp>('abc123', {
+	await users.put('abc123', {
 		uid: toUID(),
 		name: 'foobar'
 	})
-);
-
-assert<boolean>(
-	await users.put('abc123', new ArrayBuffer(1))
 );
 
 assert<boolean>(
 	await users.delete('abc123')
 );
 
-// ---
-
-class App extends Entity<IApp> {
-	prefix = 'apps';
-}
-
-let apps2 = new App(ns);
-
-assert<IApp|null>(
-	await apps2.get('abc123')
-);
-
-assert<IApp|null>(
-	await apps2.get<IApp>('abc123', 'json')
-);
-
-assert<string|null>(
-	await apps2.get('abc123', 'text')
-);
-
-assert<ArrayBuffer|null>(
-	await apps2.get('abc123', 'arrayBuffer')
-);
-
-// @ts-expect-error - T w/ "text"
-await apps2.get<number>('abc123', 'text');
-
-// @ts-expect-error - T w/ "arrayBuffer"
-await apps2.get<number>('abc123', 'arrayBuffer');
-
-assert<boolean>(
-	await apps2.put('abc123', null)
-);
-
-assert<boolean>(
-	await apps2.put('abc123', 'foobar')
-);
-
-assert<boolean>(
-	await apps2.put<IApp>('abc123', {
-		uid: toUID(),
-		name: 'foobar'
-	})
-);
-
-assert<boolean>(
-	await apps2.put('abc123', new ArrayBuffer(1))
-);
-
-assert<boolean>(
-	await apps2.delete('abc123')
-);
-
-assert<number>(apps2.ttl!);
-assert<string>(apps2.prefix!);
+assert<number>(users.ttl!);
+assert<string>(users.prefix!);


### PR DESCRIPTION
Removes the `format` argument from `Entity.get` and `Entity.delete` methods. Means that users can only use JSON data types, which is likely the 99% use case. This primarily simplifies type-complexity, not code-complexity. AKA, it's muchhh nicer to define the type argument on class definition than needing to pass in a type-argument everywhere a `thing.get()` appears.